### PR TITLE
Make directory json response, include issuers if present

### DIFF
--- a/app/controllers/spree/adyen/hpps_controller.rb
+++ b/app/controllers/spree/adyen/hpps_controller.rb
@@ -5,6 +5,10 @@ module Spree
 
     def directory
       @brands = Adyen::Form.payment_methods_from_directory @order, @payment_method
+      respond_to do |format|
+        format.html
+        format.json { render json: @brands }
+      end
     end
   end
 end

--- a/app/views/spree/adyen/hpps/directory.html.erb
+++ b/app/views/spree/adyen/hpps/directory.html.erb
@@ -1,10 +1,10 @@
 <dl>
   <% @brands.each do |brand| %>
     <dt>
-      <%= brand['brandCode'] %>
+      <%= brand[:brand_code] %>
     </dt>
     <dd>
-      <%= link_to brand['name'], ::Spree::Adyen::Form.details_url(@order, @payment_method, brand).to_s %>
+      <%= link_to brand[:name], brand[:payment_url] %>
     </dd>
   <% end %>
 </dl>

--- a/lib/spree/adyen/form.rb
+++ b/lib/spree/adyen/form.rb
@@ -61,10 +61,10 @@ module Spree::Adyen::Form
 
     def form_payment_methods_and_urls response, order, payment_method
       response.map do |brand|
-        issuers = brand['issuers'].map do |issuer|
-          form_issue(issuer, order, payment_method, brand)
+        issuers = brand.fetch('issuers', []).map do |issuer|
+          form_issuer(issuer, order, payment_method, brand)
         end
-        form_payment_method(brand, order, payment_method, brand, issuers)
+        form_payment_method(brand, order, payment_method, issuers)
       end
     end
 

--- a/lib/spree/adyen/form.rb
+++ b/lib/spree/adyen/form.rb
@@ -74,8 +74,8 @@ module Spree::Adyen::Form
         payment_url: Spree::Adyen::Form.details_url_with_issuer(
           order,
           payment_method,
-          brand,
-          issuer
+          brand['brandCode'],
+          issuer['issuerId']
         ).to_s
       }
     end

--- a/lib/spree/adyen/form.rb
+++ b/lib/spree/adyen/form.rb
@@ -60,24 +60,12 @@ module Spree::Adyen::Form
     end
 
     def form_payment_methods_and_urls response, order, payment_method
-      payment_methods = []
-      response.each do |brand|
-        if brand['issuers']
-          issuers = []
-          brand['issuers'].each do |issuer|
-            issuers << form_issuer(issuer, order, payment_method, brand)
-          end
-          payment_methods << form_payment_method(
-            brand,
-            order,
-            payment_method,
-            issuers
-          )
-        else
-          payment_methods << form_payment_method(brand, order, payment_method)
+      response.map do |brand|
+        issuers = brand['issuers'].map do |issuer|
+          form_issue(issuer, order, payment_method, brand)
         end
+        form_payment_method(brand, order, payment_method, brand, issuers)
       end
-      payment_methods
     end
 
     def form_issuer issuer, order, payment_method, brand
@@ -92,7 +80,7 @@ module Spree::Adyen::Form
       }
     end
 
-    def form_payment_method brand, order, payment_method, issuers = nil
+    def form_payment_method brand, order, payment_method, issuers
       {
         brand_code: brand['brandCode'],
         name: brand['name'],

--- a/lib/spree/adyen/form.rb
+++ b/lib/spree/adyen/form.rb
@@ -59,45 +59,50 @@ module Spree::Adyen::Form
       Form.url(server, endpoint)
     end
 
-    def form_payment_methods_and_urls(response, order, payment_method)
+    def form_payment_methods_and_urls response, order, payment_method
       payment_methods = []
       response.each do |brand|
         if brand['issuers']
           issuers = []
           brand['issuers'].each do |issuer|
-            issuers << {
-              name: issuer['name'],
-              payment_url: Spree::Adyen::Form.details_url_with_issuer(
-                order,
-                payment_method,
-                brand,
-                issuer
-              ).to_s
-            }
+            issuers << form_issuer(issuer, order, payment_method, brand)
           end
-          payment_methods << {
-            brand_code: brand['brandCode'],
-            name: brand['name'],
-            payment_url: Spree::Adyen::Form.details_url(
-              order,
-              payment_method,
-              brand
-            ).to_s,
-            issuers: issuers
-          }
+          payment_methods << form_payment_method(
+            brand,
+            order,
+            payment_method,
+            issuers
+          )
         else
-          payment_methods << {
-            brand_code: brand['brandCode'],
-            name: brand['name'],
-            payment_url: Spree::Adyen::Form.details_url(
-              order,
-              payment_method,
-              brand
-            ).to_s
-          }
+          payment_methods << form_payment_method(brand, order, payment_method)
         end
       end
       payment_methods
+    end
+
+    def form_issuer issuer, order, payment_method, brand
+      {
+        name: issuer['name'],
+        payment_url: Spree::Adyen::Form.details_url_with_issuer(
+          order,
+          payment_method,
+          brand,
+          issuer
+        ).to_s
+      }
+    end
+
+    def form_payment_method brand, order, payment_method, issuers = nil
+      {
+        brand_code: brand['brandCode'],
+        name: brand['name'],
+        payment_url: Spree::Adyen::Form.details_url(
+          order,
+          payment_method,
+          brand
+        ).to_s,
+        issuers: issuers
+      }
     end
 
     def params order, payment_method

--- a/lib/spree/adyen/form.rb
+++ b/lib/spree/adyen/form.rb
@@ -48,7 +48,7 @@ module Spree::Adyen::Form
       url = ::Spree::Adyen::Form.directory_url(order, payment_method)
 
       form_payment_methods_and_urls(
-        JSON.parse(::Net::HTTP.get(url)).fetch('paymentMethods'),
+        JSON.parse(::Net::HTTP.get(url)),
         order,
         payment_method
       )
@@ -60,7 +60,7 @@ module Spree::Adyen::Form
     end
 
     def form_payment_methods_and_urls response, order, payment_method
-      response.map do |brand|
+      response.fetch('paymentMethods').map do |brand|
         issuers = brand.fetch('issuers', []).map do |issuer|
           form_issuer(issuer, order, payment_method, brand)
         end

--- a/lib/spree/adyen/form.rb
+++ b/lib/spree/adyen/form.rb
@@ -17,19 +17,19 @@ module Spree::Adyen::Form
       endpoint_url 'directory', order, payment_method
     end
 
-    def details_url order, payment_method, directory_entry
+    def details_url order, payment_method, brand_code
       endpoint_url(
-        'details', order, payment_method, directory_entry.slice('brandCode'))
+        'details', order, payment_method, { brandCode: brand_code })
     end
 
-    def details_url_with_issuer order, payment_method, directory_entry, issuer
+    def details_url_with_issuer order, payment_method, brand_code, issuer_id
       endpoint_url(
         'details',
         order,
         payment_method,
         {
-          brandCode: directory_entry['brandCode'],
-          issuerId: issuer['issuerId']
+          brandCode: brand_code,
+          issuerId: issuer_id
         }
       )
     end
@@ -87,7 +87,7 @@ module Spree::Adyen::Form
         payment_url: Spree::Adyen::Form.details_url(
           order,
           payment_method,
-          brand
+          brand['brandCode']
         ).to_s,
         issuers: issuers
       }

--- a/spec/controllers/spree/adyen/hpps_controller_spec.rb
+++ b/spec/controllers/spree/adyen/hpps_controller_spec.rb
@@ -2,23 +2,42 @@ require "spec_helper"
 
 RSpec.describe Spree::Adyen::HppsController, type: :controller do
   describe 'GET directory' do
-    subject {
-      get :directory,
-      order_id: order.id,
-      payment_method_id: payment_method.id }
-
     let(:order) { create :order }
     let(:payment_method) { create :hpp_gateway }
+    let(:parsed_directory_response) { [{
+      name: 'American Express',
+      brandCode: 'amex',
+      payment_url: 'www.test-payment-url.com/amex'}] }
 
     before do
       allow(Spree::Adyen::Form).to receive(:payment_methods_from_directory).
         with(order, payment_method).
-        and_return([{
-          'name' => 'American Express',
-          'brandCode' => 'amex'}])
+        and_return(parsed_directory_response)
     end
 
-    it { is_expected.to have_http_status :ok }
-    it { is_expected.to render_template 'directory' }
+    context 'html response' do
+      subject {
+        get :directory,
+        order_id: order.id,
+        payment_method_id: payment_method.id }
+
+      it { is_expected.to have_http_status :ok }
+      it { is_expected.to render_template 'directory' }
+    end
+
+    context 'json response' do
+      subject {
+        get :directory,
+        order_id: order.id,
+        payment_method_id: payment_method.id,
+        format: :json }
+
+      it { is_expected.to have_http_status :ok }
+      
+      it "renders a json response" do
+        subject
+        expect(response.body).to eq parsed_directory_response.to_json
+      end
+    end
   end
 end

--- a/spec/lib/spree/adyen/form_spec.rb
+++ b/spec/lib/spree/adyen/form_spec.rb
@@ -165,35 +165,39 @@ RSpec.describe Spree::Adyen::Form do
   end
 
   describe "details_url" do
-    let(:directory_entry) { { "name" => "PayPal", "brandCode" => "paypal" } }
+    let(:brand_code) { "paypal" }
     subject { 
-      described_class.details_url(order, payment_method, directory_entry) 
+      described_class.details_url(order, payment_method, brand_code) 
     }
 
     it "calls endpoint url with the expected params" do
       expect(described_class).to receive(:endpoint_url).
-        with("details", order, payment_method, { "brandCode" => "paypal" })
+        with("details", order, payment_method, { brandCode: "paypal" })
       subject
     end
   end
 
   describe "details_url_with_issuer" do
-    let(:issuer) { { "name" => "isser01", "issuerId" => "1654" } }
-    let(:directory_entry) {
-      {
-        "name" => "PayPal",
-        "brandCode" => "paypal",
-        "issuers" => [issuer]
-      }
-    }
+    let(:issuer_id) { "1654" }
+    let(:brand_code) { "paypal" }
     
     subject { 
-      described_class.details_url_with_issuer(order, payment_method, directory_entry, issuer) 
+      described_class.details_url_with_issuer(
+        order,
+        payment_method,
+        brand_code,
+        issuer_id
+      ) 
     }
 
     it "calls endpoint url with the expected params" do
       expect(described_class).to receive(:endpoint_url).
-        with("details", order, payment_method, { brandCode: "paypal", issuerId: "1654" })
+        with(
+          "details",
+          order,
+          payment_method,
+          { brandCode: "paypal", issuerId: "1654" }
+        )
       subject
     end
   end

--- a/spec/lib/spree/adyen/form_spec.rb
+++ b/spec/lib/spree/adyen/form_spec.rb
@@ -1,22 +1,20 @@
 require "spec_helper"
 
 RSpec.describe Spree::Adyen::Form do
+  let(:order) { create :order, total: 99.0 }
+  let(:payment_method) { create :hpp_gateway, preferences: preferences }
+  let(:preferences){
+    {server: "test",
+     test_mode: true,
+     api_username: "username",
+     api_password: "password",
+     merchant_account: "account",
+     skin_code: "XXXXXX",
+     shared_secret: "1234567890",
+     days_to_ship: 3}
+  }
+
   describe "directory_url" do
-    let(:order) { create :order, total: 99.0 }
-
-    let(:payment_method) { create :hpp_gateway, preferences: preferences }
-
-    let(:preferences){
-      {server: "test",
-       test_mode: true,
-       api_username: "username",
-       api_password: "password",
-       merchant_account: "account",
-       skin_code: "XXXXXX",
-       shared_secret: "1234567890",
-       days_to_ship: 3}
-    }
-
     let(:expected) do
       redirect_params = {
         currency_code: order.currency,
@@ -55,6 +53,148 @@ RSpec.describe Spree::Adyen::Form do
       it 'has the proper protocol and host' do
         expect(URI(subject).host).to eq 'live.adyen.com'
       end
+    end
+  end
+
+  describe "payment_methods" do
+    let(:adyen_response) { '{ "test": "response" }' }
+    let(:fake_directory_url) { "www.directory-url.com" }
+
+    before do
+      allow(described_class).to receive(:directory_url).
+        and_return(fake_directory_url)
+      allow(::Net::HTTP).to receive(:get).
+        with(fake_directory_url).
+        and_return(adyen_response)
+    end
+
+    subject { described_class.send(:payment_methods, order, payment_method) }
+
+    it "calls form_payment_methods_and_urls with adyen response" do
+      expect(described_class).to receive(:form_payment_methods_and_urls).
+        with({ "test" => "response" }, order, payment_method)
+      subject
+    end
+  end
+
+  describe "form_payment_methods_and_urls" do
+    let(:payment_url) { "www.test-url.com" }
+    let(:issuer_payment_url) { "www.issuer-test-url.com" }
+
+    before do
+      allow(described_class).to receive(:details_url).
+        and_return(payment_url)
+      allow(described_class).to receive(:details_url_with_issuer).
+        and_return(issuer_payment_url)
+
+    end
+
+    subject { described_class.send(
+      :form_payment_methods_and_urls,
+      adyen_response,
+      order,
+      payment_method
+    ) }
+
+    context "payment method without issuers" do
+      let(:adyen_response) {
+        {
+          "paymentMethods" => [
+            {
+              "brandCode" => "paypal",
+              "name" => "PayPal"
+            }
+          ]
+        }
+      }
+
+      it "returns processed response with urls" do
+        expect(subject).to eq [
+          {
+            name: "PayPal",
+            brand_code: "paypal",
+            payment_url: payment_url,
+            issuers: []
+          }
+        ]
+      end
+    end
+
+    context "payment method with issuers" do
+      let(:adyen_response) {
+        {
+          "paymentMethods" => [
+            {
+              "brandCode" => "ideal",
+              "name" => "iDEAL",
+              "issuers" => [
+                {
+                  "name" => "issuer01",
+                  "issuerId" => "1157"
+                },
+                {
+                  "name" => "issuer02",
+                  "issuerId" => "1184"
+                }
+              ]
+            }
+          ]
+        }
+      }
+
+      it "returns processed response with urls" do
+        expect(subject).to eq [
+          {
+            name: "iDEAL",
+            brand_code: "ideal",
+            payment_url: payment_url,
+            issuers: [
+              {
+                name: "issuer01",
+                payment_url: issuer_payment_url
+              },
+              {
+                name: "issuer02",
+                payment_url: issuer_payment_url
+              }
+            ]
+          }
+        ]
+      end
+    end
+  end
+
+  describe "details_url" do
+    let(:directory_entry) { { "name" => "PayPal", "brandCode" => "paypal" } }
+    subject { 
+      described_class.details_url(order, payment_method, directory_entry) 
+    }
+
+    it "calls endpoint url with the expected params" do
+      expect(described_class).to receive(:endpoint_url).
+        with("details", order, payment_method, { "brandCode" => "paypal" })
+      subject
+    end
+  end
+
+  describe "details_url_with_issuer" do
+    let(:issuer) { { "name" => "isser01", "issuerId" => "1654" } }
+    let(:directory_entry) {
+      {
+        "name" => "PayPal",
+        "brandCode" => "paypal",
+        "issuers" => [issuer]
+      }
+    }
+    
+    subject { 
+      described_class.details_url_with_issuer(order, payment_method, directory_entry, issuer) 
+    }
+
+    it "calls endpoint url with the expected params" do
+      expect(described_class).to receive(:endpoint_url).
+        with("details", order, payment_method, { brandCode: "paypal", issuerId: "1654" })
+      subject
     end
   end
 


### PR DESCRIPTION
Currently the directory lookup ignores payment method issuers if they're returned by Adyen. This PR allows you to get at the issuers by requesting a json version of the directory lookup, which includes issuers and their urls.

Thanks for the work you've already done on this for us regarding directory lookup. I noticed the issuers were missing in your template, and whilst these aren't strictly necessary (if you don't specify an issuer for a payment method which uses them, like iDEAL, you just select the issuer on the first Adyen page) by putting them in the initial payment page (often in a select box), you skip an extra step on Adyen's side. As not dealing with issuers is perfectly valid I've left your partial and ajax way of getting the payment methods working just as they did, but if you get the json version instead you have the issuer urls which you can format on your page as you wish.

Happy to make changes if you don't think this pushes in the right direction, what do you think?
