### PR TITLE
User order.currency rather than Spree's currency.

### DIFF
--- a/lib/spree/adyen/form.rb
+++ b/lib/spree/adyen/form.rb
@@ -48,14 +48,14 @@ module Spree::Adyen::Form
 
     # TODO set this in the adyen config
     def default_params
-      { currency_code: Spree::Config.currency,
-        ship_before_date: Date.tomorrow,
+      { ship_before_date: Date.tomorrow,
         session_validity: 10.minutes.from_now,
         recurring: false }
     end
 
     def order_params order
-      { merchant_reference: order.number.to_s,
+      { currency_code: order.currency,
+        merchant_reference: order.number.to_s,
         country_code: order.billing_address.country.iso3,
         payment_amount: (order.total.to_f * 100).to_int }
     end

--- a/spec/lib/spree/adyen/form_spec.rb
+++ b/spec/lib/spree/adyen/form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Spree::Adyen::Form do
 
     let(:expected) do
       redirect_params = {
-        currency_code: Spree::Config.currency,
+        currency_code: order.currency,
         ship_before_date: Date.tomorrow,
         session_validity: 10.minutes.from_now,
         recurring: false,


### PR DESCRIPTION
The currency used when sending a payment to Adyen was the Spree currency rather than the order's currency. This switches it to the order for ecomm sites which deal in multiple currencies.
