### PR TITLE
Add helper for select url

### DIFF
--- a/lib/spree/adyen/form.rb
+++ b/lib/spree/adyen/form.rb
@@ -9,6 +9,9 @@ module Spree::Adyen::Form
       payment_methods(order, payment_method).fetch('paymentMethods')
     end
 
+    def select_url order, payment_method
+      endpoint_url 'select', order, payment_method
+    end
 
     def directory_url order, payment_method
       endpoint_url 'directory', order, payment_method


### PR DESCRIPTION
When someone is using out checkout without javascript we still want to be able to offer Adyen payments, by sending them to the 'select' stage of the Adyen payment process. This helper allows you to get the select url without calling `endpoint_url` directly.
