### PR TITLE
Move ship before date to config for payment method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ source "http://rubygems.org"
 gemspec
 
 gem 'adyen', github: 'huoxito/adyen', branch: 'enhanced'
+
+group :test do
+  gem 'timecop'
+end

--- a/app/models/spree/gateway/adyen_hpp.rb
+++ b/app/models/spree/gateway/adyen_hpp.rb
@@ -5,7 +5,7 @@ module Spree
 
     preference :skin_code, :string
     preference :shared_secret, :string
-    preference :days_to_ship, :integer
+    preference :days_to_ship, :integer, default: 1
 
     def auto_capture?
       false
@@ -24,8 +24,7 @@ module Spree
     end
 
     def ship_before_date
-      days_to_ship = (ENV['ADYEN_DAYS_TO_SHIP'] || preferred_days_to_ship).to_i
-      days_to_ship.days.from_now
+      preferred_days_to_ship.days.from_now
     end
 
     def authorize(amount, source, gateway_options)

--- a/app/models/spree/gateway/adyen_hpp.rb
+++ b/app/models/spree/gateway/adyen_hpp.rb
@@ -5,6 +5,7 @@ module Spree
 
     preference :skin_code, :string
     preference :shared_secret, :string
+    preference :days_to_ship, :integer
 
     def auto_capture?
       false
@@ -20,6 +21,11 @@ module Spree
 
     def skin_code
       ENV['ADYEN_SKIN_CODE'] || preferred_skin_code
+    end
+
+    def ship_before_date
+      days_to_ship = (ENV['ADYEN_DAYS_TO_SHIP'] || preferred_days_to_ship).to_i
+      days_to_ship.days.from_now
     end
 
     def authorize(amount, source, gateway_options)

--- a/db/migrate/20151007090519_add_days_to_ship_to_config.rb
+++ b/db/migrate/20151007090519_add_days_to_ship_to_config.rb
@@ -1,0 +1,5 @@
+class AddDaysToShipToConfig < ActiveRecord::Migration
+  def change
+    add_column :spree_adyen_hpp_sources, :days_to_ship, :integer
+  end
+end

--- a/lib/spree/adyen/form.rb
+++ b/lib/spree/adyen/form.rb
@@ -51,8 +51,7 @@ module Spree::Adyen::Form
 
     # TODO set this in the adyen config
     def default_params
-      { ship_before_date: Date.tomorrow,
-        session_validity: 10.minutes.from_now,
+      { session_validity: 10.minutes.from_now,
         recurring: false }
     end
 
@@ -66,7 +65,8 @@ module Spree::Adyen::Form
     def payment_method_params payment_method
       { merchant_account: payment_method.merchant_account,
         skin_code: payment_method.skin_code,
-        shared_secret: payment_method.shared_secret }
+        shared_secret: payment_method.shared_secret,
+        ship_before_date: payment_method.ship_before_date }
     end
   end
 end

--- a/spec/factories/spree_gateway_adyen_hpp.rb
+++ b/spec/factories/spree_gateway_adyen_hpp.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
     preferences(
       skin_code: 'XXXXX',
       shared_secret: '1234',
-      merchant_account: 'XXXX')
+      merchant_account: 'XXXX',
+      days_to_ship: 3)
   end
 end

--- a/spec/lib/spree/adyen/form_spec.rb
+++ b/spec/lib/spree/adyen/form_spec.rb
@@ -13,13 +13,14 @@ RSpec.describe Spree::Adyen::Form do
        api_password: "password",
        merchant_account: "account",
        skin_code: "XXXXXX",
-       shared_secret: "1234567890"}
+       shared_secret: "1234567890",
+       days_to_ship: 3}
     }
 
     let(:expected) do
       redirect_params = {
         currency_code: order.currency,
-        ship_before_date: Date.tomorrow,
+        ship_before_date: 3.days.from_now,
         session_validity: 10.minutes.from_now,
         recurring: false,
         merchant_reference: order.number.to_s,

--- a/spec/models/spree/gateway/adyen_hpp_spec.rb
+++ b/spec/models/spree/gateway/adyen_hpp_spec.rb
@@ -24,5 +24,26 @@ module Spree
         end
       end
     end
+
+    context "calculate ship_before_date" do
+      let(:test_time) { Time.local(2015, 9, 1, 12, 0, 0) }
+
+      context "days_to_ship has been set" do
+        it "returns tomorrow" do
+          Timecop.freeze(test_time) do
+            expect(subject.ship_before_date).to eq  Time.local(2015, 9, 2, 12, 0, 0)
+          end
+        end
+      end
+
+      context "days_to_ship has not been set" do
+        it "returns date days_to_ship in the future" do
+          subject.preferred_days_to_ship = 3
+          Timecop.freeze(test_time) do
+            expect(subject.ship_before_date).to eq  Time.local(2015, 9, 4, 12, 0, 0)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The mandatory field 'ship before date' was hard coded at 1 day. This adds a 'days to ship' config to the payment method so this can be more easily adjusted.

May need to be more complicated (hooking into business days, holiday, current shop demand, etc.) in the future, but this is a start.
