### PR TITLE
Add shoulda-matcher config for old tests to pass

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,3 +61,10 @@ VCR.configure do |c|
   c.cassette_library_dir = 'spec/cassettes'
   c.hook_into :webmock
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
Some of the model tests weren't working for me, because it didn't load in the ShouldaMatcher methods. This sorts it out.
