### PR TITLE
Use iso rather than iso3 for country code

### DIFF
--- a/lib/spree/adyen/form.rb
+++ b/lib/spree/adyen/form.rb
@@ -59,7 +59,7 @@ module Spree::Adyen::Form
     def order_params order
       { currency_code: order.currency,
         merchant_reference: order.number.to_s,
-        country_code: order.billing_address.country.iso3,
+        country_code: order.billing_address.country.iso,
         payment_amount: (order.total.to_f * 100).to_int }
     end
 

--- a/spec/lib/spree/adyen/form_spec.rb
+++ b/spec/lib/spree/adyen/form_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Spree::Adyen::Form do
         merchant_account: payment_method.merchant_account,
         skin_code: payment_method.skin_code,
         shared_secret: payment_method.shared_secret,
-        country_code: order.billing_address.country.iso3,
+        country_code: order.billing_address.country.iso,
         payment_amount: (order.total.to_f * 100).to_int }
 
        ::Adyen::Form.redirect_url(redirect_params)


### PR DESCRIPTION
Adyen's country code field uses two letter rather than three letter iso codes for determining the country. Passing iso3 codes defaulted back to their IP based country detection (which gave me an awful fright when it wasn't working on a heroku box based in the US).
