### PR TITLE
Auto send manual capture requests

### DIFF
--- a/lib/spree/adyen/notification_processing.rb
+++ b/lib/spree/adyen/notification_processing.rb
@@ -68,6 +68,8 @@ module Spree::Adyen::NotificationProcessing
   def self.handle_normal_event notification, payment
     if auto_captured? notification, payment
       complete_payment! notification, payment
+    else
+      payment.adyen_hpp_capture!
     end
   end
 


### PR DESCRIPTION
If a payment isn't in the Adyen 'auto-capture' list, send an auto-capture request after a successful auth.

Extension of this may be to add a delay, but this is the minimum functionality we require right now.

I considered doing it as a worker, but as Adyen just give back a 'we've got your request' it should hopefully be fast enough as it is.
