### PR TITLE
Refactor notification processing to make it easier to call from other places

### DIFF
--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -13,18 +13,7 @@ class Spree::AdyenNotificationsController < Spree::StoreController
     # if a failure occurs we don't want to send anything, it wil be
     # interpretted as a success.
     AdyenNotification.transaction do
-      payment =
-        Spree::Adyen::NotificationProcessing.find_payment(notification)
-
-      # only process the notification if there is a matching payment
-      # there's a number of reasons why there may not be a matching payment
-      # such as test notifications, reports etc, we just log them and then
-      # accept
-      if payment
-        Spree::Adyen::NotificationProcessing.process notification, payment
-      end
-
-      notification.save!
+      Spree::Adyen::NotificationProcessing.process notification
     end
 
     # accept after processing has completed

--- a/spec/lib/spree/adyen/notification_processing_spec.rb
+++ b/spec/lib/spree/adyen/notification_processing_spec.rb
@@ -33,7 +33,13 @@ RSpec.describe Spree::Adyen::NotificationProcessing do
   end
 
   describe "#process/2" do
-    subject { described_class.process(notification, payment)}
+    subject { described_class.process(notification)}
+
+    before do
+      allow(Spree::Adyen::NotificationProcessing).to(
+        receive(:find_payment).with(notification).and_return(payment)
+      )
+    end
 
     let!(:payment) do
       create(:payment, state: payment_state, payment_method: hpp_gateway)


### PR DESCRIPTION
We've been seeing on our staging server that the notification from Adyen comes in before the payment is persisted, leading to unprocessed notifications (and stuck payments). We're going to set up a rake task to process unprocessed notifications. This refactor makes it simpler to call one thing to do this (and thins down the notifications_controller).
