### PR TITLE
Update set of auto-capture-only methods to include Sofort.

### DIFF
--- a/lib/spree/adyen/notification_processing.rb
+++ b/lib/spree/adyen/notification_processing.rb
@@ -1,5 +1,5 @@
 module Spree::Adyen::NotificationProcessing
-  AUTO_CAPTURE_ONLY_METHODS = [ "ideal", "c_cash" ].freeze
+  AUTO_CAPTURE_ONLY_METHODS = [ "ideal", "c_cash", "directEbanking" ].freeze
 
   AUTHORISATION = "AUTHORISATION".freeze
   CANCELLATION = "CANCELLATION".freeze


### PR DESCRIPTION
Sofort was being treated like a card payment, but it works like iDEAL.
