### PR TITLE
Don't redirect to the order complete page with a token

### DIFF
--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -33,7 +33,7 @@ module Spree
 
       if current_order.complete
         flash.notice = Spree.t(:current_order_processed_successfully)
-        redirect_to order_path(current_order, token: current_order.guest_token)
+        redirect_to order_path(current_order)
       else
         #TODO void/cancel payment
         redirect_to checkout_state_path(current_order.state)

--- a/spec/controllers/spree/adyen_redirect_controller_spec.rb
+++ b/spec/controllers/spree/adyen_redirect_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Spree::AdyenRedirectController, type: :controller do
 
       it "redirects to the order complete page" do
         is_expected.to have_http_status(:redirect).
-          and redirect_to order_path(order, token: order.guest_token)
+          and redirect_to order_path(order)
       end
 
       it "creates a pending payment" do


### PR DESCRIPTION
I don't know why this token is here, but it shouldn't be necessary?
