### PR TITLE
Cancellations

### DIFF
--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -13,7 +13,7 @@ class Spree::AdyenNotificationsController < Spree::StoreController
     # if a failure occurs we don't want to send anything, it wil be
     # interpretted as a success.
     AdyenNotification.transaction do
-      Spree::Adyen::NotificationProcessing.process notification
+      Spree::Adyen::NotificationProcessor.process notification
     end
 
     # accept after processing has completed

--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -6,7 +6,7 @@ class Spree::AdyenNotificationsController < Spree::StoreController
   def notify
     notification = AdyenNotification.build(params)
 
-    if duplicate? notification
+    if notification.duplicate?
       accept and return
     end
 
@@ -27,13 +27,5 @@ class Spree::AdyenNotificationsController < Spree::StoreController
   private
   def accept
     render text: "[accepted]"
-  end
-
-  def duplicate? notification
-    AdyenNotification.exists?(
-      psp_reference: notification.psp_reference,
-      event_code: notification.event_code,
-      success: notification.success
-    )
   end
 end

--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -13,7 +13,7 @@ class Spree::AdyenNotificationsController < Spree::StoreController
     # if a failure occurs we don't want to send anything, it wil be
     # interpretted as a success.
     AdyenNotification.transaction do
-      Spree::Adyen::NotificationProcessor.process notification
+      Spree::Adyen::NotificationProcessor.new(notification).process!
     end
 
     # accept after processing has completed

--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -10,11 +10,7 @@ class Spree::AdyenNotificationsController < Spree::StoreController
       accept and return
     end
 
-    # if a failure occurs we don't want to send anything, it wil be
-    # interpretted as a success.
-    AdyenNotification.transaction do
-      Spree::Adyen::NotificationProcessor.new(notification).process!
-    end
+    Spree::Adyen::NotificationProcessor.new(notification).process!
 
     # accept after processing has completed
     accept

--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -1,19 +1,14 @@
 module Spree
   class AdyenRedirectController < StoreController
-    PENDING = "PENDING"
-    AUTHORIZED = "AUTHORISED"
-    REFUSED = "REFUSED"
-    CANCELLED = "CANCELLED"
-
     before_filter :check_signature, only: :confirm
 
     skip_before_filter :verify_authenticity_token
 
     # This is the entry point after an Adyen HPP payment is completed
     def confirm
-      auth_result = params["authResult"]
+      source = Adyen::HppSource.new(source_params(params))
 
-      unless [PENDING, AUTHORIZED].include? auth_result
+      unless source.authorised?
         flash.notice = Spree.t(:payment_processing_failed)
         redirect_to checkout_state_path(current_order.state)
         return
@@ -22,14 +17,14 @@ module Spree
       # payment is created in a 'checkout' state so that the payment method
       # can attempt to auth it. The payment of course is already auth'd and
       # adyen hpp's authorize implementation just returns a dummy response.
-      current_order.payments.create!(
-        amount: current_order.total,
-        payment_method: payment_method,
-        response_code: params[:pspReference],
-        state: 'checkout'
-      ) do |payment|
-        payment.source = Adyen::HppSource.create!(source_params(params))
-      end
+      payment =
+        current_order.payments.create!(
+          amount: current_order.total,
+          payment_method: payment_method,
+          source: source,
+          response_code: params[:pspReference],
+          state: "checkout"
+        )
 
       if current_order.complete
         flash.notice = Spree.t(:current_order_processed_successfully)

--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -26,6 +26,10 @@ module Spree
           state: "checkout"
         )
 
+      # We may have already recieved the authorization notification, so process
+      # it now
+      Spree::Adyen::NotificationProcessor.process_outstanding!(payment)
+
       if current_order.complete
         flash.notice = Spree.t(:current_order_processed_successfully)
         redirect_to order_path(current_order)

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -54,13 +54,6 @@ class AdyenNotification < ActiveRecord::Base
   validates_presence_of :psp_reference
   validates_uniqueness_of :success, scope: [:psp_reference, :event_code]
 
-  # Make sure we don't end up with an original_reference with an empty string
-  before_validation do |notification|
-    if notification.original_reference.blank?
-      notification.original_reference = nil
-    end
-  end
-
   # Logs an incoming notification into the database.
   #
   # @param [Hash] params The notification parameters that should be stored in the database.
@@ -73,7 +66,11 @@ class AdyenNotification < ActiveRecord::Base
     self.new.tap do |notification|
       params.each do |key, value|
         setter = "#{key.to_s.underscore}="
-        notification.send(setter, value) if notification.respond_to?(setter)
+
+        # don't assign if value is empty string.
+        if notification.respond_to?(setter) && value.present?
+          notification.send(setter, value)
+        end
       end
     end
   end

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -84,11 +84,11 @@ class AdyenNotification < ActiveRecord::Base
   # @return [true, false] true iff event_code == 'AUTHORISATION'
   # @see Adyen.notification#successful_authorisation?
   def authorisation?
-    event_code == 'AUTHORISATION'
+    event_code == AUTHORISATION
   end
 
   def capture?
-    event_code == 'CAPTURE'
+    event_code == CAPTURE
   end
 
   def actions

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -48,19 +48,18 @@ class AdyenNotification < ActiveRecord::Base
 
   scope :processed, -> { where processed: true }
   scope :unprocessed, -> { where processed: false }
-
   scope :authorisation, -> { where event_code: "AUTHORISATION" }
 
-  # A notification should always include an event_code
   validates_presence_of :event_code
-
-  # A notification should always include a psp_reference
   validates_presence_of :psp_reference
-
   validates_uniqueness_of :success, scope: [:psp_reference, :event_code]
 
   # Make sure we don't end up with an original_reference with an empty string
-  before_validation { |notification| notification.original_reference = nil if notification.original_reference.blank? }
+  before_validation do |notification|
+    if notification.original_reference.blank?
+      notification.original_reference = nil
+    end
+  end
 
   # Logs an incoming notification into the database.
   #

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -47,6 +47,7 @@ class AdyenNotification < ActiveRecord::Base
     foreign_key: :merchant_reference
 
   scope :processed, -> { where processed: true }
+  scope :unprocessed, -> { where processed: false }
 
   scope :authorisation, -> { where event_code: "AUTHORISATION" }
 

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -57,6 +57,8 @@ class AdyenNotification < ActiveRecord::Base
   # A notification should always include a psp_reference
   validates_presence_of :psp_reference
 
+  validates_uniqueness_of :success, scope: [:psp_reference, :event_code]
+
   # Make sure we don't end up with an original_reference with an empty string
   before_validation { |notification| notification.original_reference = nil if notification.original_reference.blank? }
 

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -91,6 +91,10 @@ class AdyenNotification < ActiveRecord::Base
     event_code == CAPTURE
   end
 
+  def cancel_or_refund?
+    event_code == CANCEL_OR_REFUND
+  end
+
   def actions
     self.operations.
       split(",").

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -119,6 +119,14 @@ class AdyenNotification < ActiveRecord::Base
     self.payment_method.match(/^bankTransfer/)
   end
 
+  def duplicate?
+    self.class.exists?(
+      psp_reference: self.psp_reference,
+      event_code: self.event_code,
+      success: self.success
+    )
+  end
+
   def auto_captured?
     payment_method_auto_capture_only? || bank_transfer?
   end

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -68,8 +68,6 @@ class AdyenNotification < ActiveRecord::Base
   # @raise This method will raise an exception if the notification cannot be stored.
   # @see Adyen::Notification::HttpPost.log
   def self.build(params)
-    converted_params = {}
-
     # Assign explicit each attribute from CamelCase notation to notification
     # For example, merchantReference will be converted to merchant_reference
     self.new.tap do |notification|

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -46,6 +46,7 @@ class AdyenNotification < ActiveRecord::Base
     primary_key: :number,
     foreign_key: :merchant_reference
 
+  scope :as_dispatched, -> { order(event_date: :desc) }
   scope :processed, -> { where processed: true }
   scope :unprocessed, -> { where processed: false }
   scope :authorisation, -> { where event_code: "AUTHORISATION" }

--- a/app/models/spree/adyen/hpp_source.rb
+++ b/app/models/spree/adyen/hpp_source.rb
@@ -8,6 +8,11 @@
 # Information about when certain action are valid:
 # https://docs.adyen.com/display/TD/HPP+modifications
 class Spree::Adyen::HppSource < ActiveRecord::Base
+  PENDING = "PENDING"
+  AUTHORISED = "AUTHORISED"
+  REFUSED = "REFUSED"
+  CANCELLED = "CANCELLED"
+
   # support updates from capital-cased responses, which is what adyen gives us
   alias_attribute :authResult, :auth_result
   alias_attribute :pspReference, :psp_reference
@@ -43,6 +48,12 @@ class Spree::Adyen::HppSource < ActiveRecord::Base
     else
       []
     end
+  end
+
+  def authorised?
+    # Many banks return pending, this is considered a valid response and
+    # the order should proceed.
+    [PENDING, AUTHORISED].include? auth_result
   end
 
   private

--- a/app/models/spree/adyen/hpp_source.rb
+++ b/app/models/spree/adyen/hpp_source.rb
@@ -41,7 +41,7 @@ class Spree::Adyen::HppSource < ActiveRecord::Base
   end
 
   def actions
-    if modifiable?
+    if mutable?
       authorised_actions
     else
       []
@@ -54,11 +54,11 @@ class Spree::Adyen::HppSource < ActiveRecord::Base
     [PENDING, AUTHORISED].include? auth_result
   end
 
-  def modifiable?
+  private
+  def mutable?
     !payment.void? && !payment.processing?
   end
 
-  private
   # authorised_actions :: [String] | []
   def authorised_actions
     notifications.

--- a/app/models/spree/adyen/hpp_source.rb
+++ b/app/models/spree/adyen/hpp_source.rb
@@ -41,10 +41,8 @@ class Spree::Adyen::HppSource < ActiveRecord::Base
   end
 
   def actions
-    if auth_notification
-      auth_notification.
-        actions.
-        map { |action| "adyen_hpp_#{action}" }
+    if modifiable?
+      authorised_actions
     else
       []
     end

--- a/app/models/spree/adyen/hpp_source.rb
+++ b/app/models/spree/adyen/hpp_source.rb
@@ -54,8 +54,18 @@ class Spree::Adyen::HppSource < ActiveRecord::Base
     [PENDING, AUTHORISED].include? auth_result
   end
 
+  def modifiable?
+    !payment.void? && !payment.processing?
+  end
+
   private
-  def auth_notification
-    self.notifications.processed.authorisation.last
+  # authorised_actions :: [String] | []
+  def authorised_actions
+    notifications.
+      processed.
+      authorisation.
+      last.
+      try { actions }.
+      try { map { |action| "adyen_hpp_#{action}" } } || []
   end
 end

--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -72,6 +72,10 @@ class Spree::Adyen::NotificationProcessor
   def handle_modification_event
     if notification.capture?
       complete_payment!
+
+    elsif notification.cancel_or_refund?
+      payment.void
+
     end
   end
 
@@ -79,6 +83,7 @@ class Spree::Adyen::NotificationProcessor
   def handle_normal_event
     if notification.auto_captured?
       complete_payment!
+
     else
       payment.adyen_hpp_capture!
     end

--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -1,4 +1,4 @@
-module Spree::Adyen::NotificationProcessing
+class Spree::Adyen::NotificationProcessor
   AUTO_CAPTURE_ONLY_METHODS = [ "ideal", "c_cash", "directEbanking" ].freeze
 
   AUTHORISATION = "AUTHORISATION".freeze
@@ -23,7 +23,7 @@ module Spree::Adyen::NotificationProcessing
 
   def self.process notification
     payment =
-      Spree::Adyen::NotificationProcessing.find_payment(notification)
+      Spree::Adyen::NotificationProcessor.find_payment(notification)
 
     # only process the notification if there is a matching payment
     # there's a number of reasons why there may not be a matching payment

--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -1,30 +1,12 @@
 class Spree::Adyen::NotificationProcessor
-  AUTO_CAPTURE_ONLY_METHODS = [ "ideal", "c_cash", "directEbanking" ].freeze
+  attr_accessor :notification, :payment
 
-  AUTHORISATION = "AUTHORISATION".freeze
-  CANCELLATION = "CANCELLATION".freeze
-  REFUND = "REFUND".freeze
-  CANCEL_OR_REFUND = "CANCEL_OR_REFUND".freeze
-  CAPTURE = "CAPTURE".freeze
-  CAPTURE_FAILED = "CAPTURE_FAILED".freeze
-  REFUND_FAILED = "REFUND_FAILED".freeze
-  REFUNDED_REVERSED = "REFUNDED_REVERSED".freeze
-
-  def self.find_payment notification
-    reference =
-      if normal_event? notification
-        notification.psp_reference
-      else
-        notification.original_reference
-      end
-
-    Spree::Payment.find_by response_code: reference
+  def initialize(notification)
+    self.notification = notification
+    self.payment = self.notification.payment
   end
 
-  def self.process notification
-    payment =
-      Spree::Adyen::NotificationProcessor.find_payment(notification)
-
+  def process!
     # only process the notification if there is a matching payment
     # there's a number of reasons why there may not be a matching payment
     # such as test notifications, reports etc, we just log them and then
@@ -34,13 +16,13 @@ class Spree::Adyen::NotificationProcessor
       # we should not acknowledge the notification.
       Spree::Payment.transaction do
         if !notification.success?
-          handle_failure notification, payment
+          handle_failure
 
-        elsif modification_event? notification
-          handle_modification_event notification, payment
+        elsif notification.modification_event?
+          handle_modification_event
 
-        elsif normal_event? notification
-          handle_normal_event notification, payment
+        elsif notification.normal_event?
+          handle_normal_event
 
         else
           # the notification was not handled by any clause and should be logged
@@ -60,7 +42,9 @@ class Spree::Adyen::NotificationProcessor
     return notification
   end
 
-  def self.handle_failure notification, payment
+  private
+
+  def handle_failure
     # ignore failures if the payment was already completed
     return if payment.completed?
     # might have to do something else on modification events,
@@ -68,55 +52,27 @@ class Spree::Adyen::NotificationProcessor
     payment.failure!
   end
 
-  def self.handle_modification_event notification, payment
-    case notification.event_code
-    when CAPTURE
-      complete_payment! notification, payment
+  def handle_modification_event
+    if notification.capture?
+      complete_payment!
     end
   end
 
   # normal event is defined as just AUTHORISATION
-  def self.handle_normal_event notification, payment
-    if auto_captured? notification, payment
-      complete_payment! notification, payment
+  def handle_normal_event
+    if notification.auto_captured?
+      complete_payment!
     else
       payment.adyen_hpp_capture!
     end
   end
 
-  def self.complete_payment! notification, payment
+  def complete_payment!
     money = ::Money.new(notification.value, notification.currency)
 
     # this is copied from Spree::Payment::Processing#capture
     payment.capture_events.create!(amount: money.to_f)
     payment.update!(amount: payment.captured_amount)
     payment.complete!
-  end
-
-  def self.auto_captured? notification, payment
-    # todo include bank transfers
-    AUTO_CAPTURE_ONLY_METHODS.member?(notification.payment_method) ||
-      payment.payment_method.auto_capture? ||
-      bank_transfer?(notification)
-  end
-
-  # https://docs.adyen.com/display/TD/Notification+fields
-  def self.modification_event? notification
-    [ CANCELLATION,
-      REFUND,
-      CANCEL_OR_REFUND,
-      CAPTURE,
-      CAPTURE_FAILED,
-      REFUND_FAILED,
-      REFUNDED_REVERSED
-    ].member? notification.event_code
-  end
-
-  def self.normal_event? notification
-    AUTHORISATION == notification.event_code
-  end
-
-  def self.bank_transfer? notification
-    notification.payment_method.match(/^bankTransfer/)
   end
 end

--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -11,10 +11,11 @@ class Spree::Adyen::NotificationProcessor
     # there's a number of reasons why there may not be a matching payment
     # such as test notifications, reports etc, we just log them and then
     # accept
-    if payment
-      # if processing fails all modifications should be rolled back and
-      # we should not acknowledge the notification.
-      Spree::Payment.transaction do
+    #
+    # if processing fails all modifications should be rolled back and we should
+    # not acknowledge the notification.
+    Spree::Payment.transaction do
+      if payment
         if !notification.success?
           handle_failure
 
@@ -33,12 +34,13 @@ class Spree::Adyen::NotificationProcessor
           notification.processed = false
           return notification
         end
+
+        notification.processed = true
       end
 
-      notification.processed = true
+      notification.save!
     end
 
-    notification.save!
     return notification
   end
 

--- a/app/models/spree/gateway/adyen_hpp.rb
+++ b/app/models/spree/gateway/adyen_hpp.rb
@@ -54,13 +54,9 @@ module Spree
     def capture(amount, source, currency:, **_opts)
       value = { currency: currency, value: amount }
 
-      response = provider.capture_payment(source.psp_reference, value)
-
-      ActiveMerchant::Billing::Response.new(
-        response.success?,
-        JSON.pretty_generate(response.params),
-        {},
-        authorization: source.psp_reference)
+      handle_response(
+        provider.capture_payment(source.psp_reference, value),
+        source.psp_reference)
     end
 
     # According to Spree Processing class API the response object should respond
@@ -95,6 +91,17 @@ module Spree
       end
 
       response
+    end
+
+    private
+
+    def handle_response response, original_reference
+      ActiveMerchant::Billing::Response.new(
+        response.success?,
+        JSON.pretty_generate(response.params),
+        {},
+        authorization: original_reference
+      )
     end
   end
 end

--- a/app/models/spree/gateway/adyen_hpp.rb
+++ b/app/models/spree/gateway/adyen_hpp.rb
@@ -59,21 +59,10 @@ module Spree
         psp_reference)
     end
 
-    # According to Spree Processing class API the response object should respond
-    # to an authorization method which return value should be assigned to payment
-    # response_code
-    def void(response_code, gateway_options = {})
-      response = provider.cancel_payment(response_code)
-
-      if response.success?
-        def response.authorization; psp_reference; end
-      else
-        # TODO confirm the error response will always have these two methods
-        def response.to_s
-          "#{result_code} - #{refusal_reason}"
-        end
-      end
-      response
+    def cancel(psp_reference, _gateway_options = {})
+      handle_response(
+        provider.cancel_or_refund_payment(psp_reference),
+        psp_reference)
     end
 
     def credit(credit_cents, transaction_id, gateway_options = {})

--- a/app/models/spree/gateway/adyen_hpp.rb
+++ b/app/models/spree/gateway/adyen_hpp.rb
@@ -51,12 +51,12 @@ module Spree
       ActiveMerchant::Billing::Response.new(true, 'successful hpp payment')
     end
 
-    def capture(amount, source, currency:, **_opts)
+    def capture(amount, psp_reference, currency:, **_opts)
       value = { currency: currency, value: amount }
 
       handle_response(
-        provider.capture_payment(source.psp_reference, value),
-        source.psp_reference)
+        provider.capture_payment(psp_reference, value),
+        psp_reference)
     end
 
     # According to Spree Processing class API the response object should respond

--- a/app/models/spree/gateway/adyen_hpp.rb
+++ b/app/models/spree/gateway/adyen_hpp.rb
@@ -51,16 +51,16 @@ module Spree
       ActiveMerchant::Billing::Response.new(true, 'successful hpp payment')
     end
 
-    def capture(amount, response_code, currency:, **_opts)
+    def capture(amount, source, currency:, **_opts)
       value = { currency: currency, value: amount }
 
-      response = provider.capture_payment(response_code, value)
+      response = provider.capture_payment(source.psp_reference, value)
 
       ActiveMerchant::Billing::Response.new(
         response.success?,
         JSON.pretty_generate(response.params),
         {},
-        authorization: response_code)
+        authorization: source.psp_reference)
     end
 
     # According to Spree Processing class API the response object should respond

--- a/app/models/spree/gateway/adyen_hpp_bogus.rb
+++ b/app/models/spree/gateway/adyen_hpp_bogus.rb
@@ -1,0 +1,43 @@
+# This gateway is only available in test environments. It is **not** intended
+# for use via the spree back end, for that use BogusSimple.
+#
+# This is an even simpler version of BogusSimple, where all it does is respond
+# based on the success preference.
+#
+# It's suggested use is via the factory, via
+#   `create :bogus_hpp_gateway, (:forced_success|:forced_failure)`
+#
+class Spree::Gateway::AdyenHPPBogus < Spree::Gateway::AdyenHPP
+  preference :success, :bool, default: true
+
+  def method_type
+    "Adyen Bogus"
+  end
+
+  def environment
+    "test"
+  end
+
+  def provider
+    raise "Adyen Hpp Bogus has no provider"
+  end
+
+  def authorize(amount, source, gateway_options)
+    FactoryGirl.create :active_merchant_billing_response,
+      success: preferred_success
+  end
+
+  def capture(amount, response_code, _options)
+    FactoryGirl.create :active_merchant_billing_response,
+      success: preferred_success,
+      options: { authorization: response_code }
+  end
+
+  def void(response_code, gateway_options = {})
+    raise NotImplementedError
+  end
+
+  def credit(credit_cents, transaction_id, gateway_options = {})
+    raise NotImplementedError
+  end
+end

--- a/lib/spree/adyen/form.rb
+++ b/lib/spree/adyen/form.rb
@@ -109,7 +109,7 @@ module Spree::Adyen::Form
       { currency_code: order.currency,
         merchant_reference: order.number.to_s,
         country_code: order.billing_address.country.iso,
-        payment_amount: (order.total.to_f * 100).to_int }
+        payment_amount: (order.total * 100).to_int }
     end
 
     def payment_method_params payment_method

--- a/lib/spree/adyen/payment.rb
+++ b/lib/spree/adyen/payment.rb
@@ -4,18 +4,10 @@
 # result is false positives (payment could fail after capture).
 module Spree::Adyen::Payment
   def adyen_hpp_capture!
-    # essentially one half of Spree::Payment#capture!
-    # other half happens in the notification processing
-    amount ||= money.money.cents
     started_processing!
-
-    response = payment_method.capture(
-      amount,
-      response_code,
-      gateway_options
-    )
-
-    record_response(response)
+    # success state must remain as processing, it will change to completed
+    # once the notification is received
+    gateway_action(source, :capture, :started_processing)
   end
 
   def adyen_hpp_refund!

--- a/lib/spree/adyen/payment.rb
+++ b/lib/spree/adyen/payment.rb
@@ -7,7 +7,7 @@ module Spree::Adyen::Payment
     started_processing!
     # success state must remain as processing, it will change to completed
     # once the notification is received
-    gateway_action(source, :capture, :started_processing)
+    gateway_action(response_code, :capture, :started_processing)
   end
 
   def adyen_hpp_refund!

--- a/lib/spree/adyen/payment.rb
+++ b/lib/spree/adyen/payment.rb
@@ -3,6 +3,7 @@
 # standard capture! and friends as they change the payment state and would
 # result is false positives (payment could fail after capture).
 module Spree::Adyen::Payment
+  # adyen_hpp_capture! :: bool | error
   def adyen_hpp_capture!
     started_processing!
     # success state must remain as processing, it will change to completed
@@ -10,11 +11,30 @@ module Spree::Adyen::Payment
     gateway_action(response_code, :capture, :started_processing)
   end
 
+  # adyen_hpp_refund! :: bool | error
   def adyen_hpp_refund!
     raise NotImplementedError
   end
 
+  # adyen_hpp_cancel! :: bool | error
+  #
+  # Borrowed from handle_void_response, this has been modified so that it won't
+  # actually void the payment _yet_.
   def adyen_hpp_cancel!
-    raise NotImplementedError
+    started_processing!
+
+    response = payment_method.cancel response_code
+    record_response(response)
+
+    if response.success?
+      # The payments controller's fire action expects a truthy value to
+      # indicate success
+      true
+    else
+      # this is done to be consistent with capture, but we might actually
+      # want them to just return to the previous state
+      self.failure
+      gateway_error(response)
+    end
   end
 end

--- a/spec/controllers/spree/adyen_notifications_controller_spec.rb
+++ b/spec/controllers/spree/adyen_notifications_controller_spec.rb
@@ -20,7 +20,13 @@ describe Spree::AdyenNotificationsController do
       "live" => "false" }
   end
 
-  let!(:payment) { create :payment, response_code: reference }
+  let!(:payment) do
+    create :payment, response_code: reference,
+      payment_method: payment_method
+  end
+
+  let(:payment_method) { create :bogus_hpp_gateway, :forced_success }
+
   let(:reference) { "8513823667306210" }
 
   before do

--- a/spec/controllers/spree/adyen_redirect_controller_spec.rb
+++ b/spec/controllers/spree/adyen_redirect_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 # https://docs.adyen.com/display/TD/HPP+payment+response
 RSpec.describe Spree::AdyenRedirectController, type: :controller do
   let(:order) { create(:order_with_line_items, state: "payment") }
-  let(:payment_method) { create :hpp_gateway }
+  let(:payment_method) { create :bogus_hpp_gateway }
 
   before do
     allow(controller).to receive(:current_order).and_return order

--- a/spec/controllers/spree/adyen_redirect_controller_spec.rb
+++ b/spec/controllers/spree/adyen_redirect_controller_spec.rb
@@ -58,14 +58,14 @@ RSpec.describe Spree::AdyenRedirectController, type: :controller do
       end
     end
 
-    context "when the payment is AUTHORIZED" do
+    context "when the payment is AUTHORISED" do
       include_examples "payment is successful"
-      let(:auth_result) { described_class::AUTHORIZED }
+      let(:auth_result) { "AUTHORISED" }
     end
 
     context "when the payment is PENDING" do
       include_examples "payment is successful"
-      let(:auth_result) { described_class::PENDING }
+      let(:auth_result) { "PENDING" }
     end
 
     shared_examples "payment is not successful" do
@@ -81,12 +81,12 @@ RSpec.describe Spree::AdyenRedirectController, type: :controller do
 
     context "when the payment is CANCELLED" do
       include_examples "payment is not successful"
-      let(:auth_result) { described_class::CANCELLED }
+      let(:auth_result) { "CANCELLED" }
     end
 
     context "when the payment is REFUSED" do
       include_examples "payment is not successful"
-      let(:auth_result) { described_class::REFUSED }
+      let(:auth_result) { "REFUSED" }
     end
   end
 end

--- a/spec/factories/active_merchant_billing_response.rb
+++ b/spec/factories/active_merchant_billing_response.rb
@@ -1,0 +1,23 @@
+FactoryGirl.define do
+  factory(
+    :active_merchant_billing_response,
+    aliases: ['am_response'],
+    class: 'ActiveMerchant::Billing::Response'
+  ) do
+    skip_create
+    params Hash.new
+    options Hash.new
+    message ""
+
+    initialize_with { new(success, message, params, options) }
+
+    trait :success do
+      success true
+    end
+
+    trait :failure do
+      success false
+      message "This is an expected failure"
+    end
+  end
+end

--- a/spec/factories/adyen_notification.rb
+++ b/spec/factories/adyen_notification.rb
@@ -17,7 +17,28 @@ FactoryGirl.define do
      created_at DateTime.now
      updated_at DateTime.now
 
+     transient do
+       payment nil
+     end
+
+     trait :normal_event do
+       before(:create) do |record, evaluator|
+         if evaluator.payment
+           record.psp_reference = evaluator.payment.response_code
+         end
+       end
+     end
+
+     trait :modification_event do
+       before(:create) do |record, evaluator|
+         if evaluator.payment
+           record.original_reference = evaluator.payment.response_code
+         end
+       end
+     end
+
      trait :auth do
+       normal_event
        event_code "AUTHORISATION"
        operations "CANCEL,CAPTURE,REFUND"
        reason "31893:0002:8/2018"
@@ -34,14 +55,17 @@ FactoryGirl.define do
      end
 
      trait :capture do
+       modification_event
        event_code "CAPTURE"
      end
 
      trait :refund do
+       modification_event
        event_code "REFUND"
      end
 
      trait :pending do
+       normal_event
        event_code "PENDING"
      end
   end

--- a/spec/factories/adyen_notification.rb
+++ b/spec/factories/adyen_notification.rb
@@ -65,6 +65,11 @@ FactoryGirl.define do
        event_code "CAPTURE"
      end
 
+     trait :cancel_or_refund do
+       modification_event
+       event_code "CANCEL_OR_REFUND"
+     end
+
      trait :refund do
        modification_event
        event_code "REFUND"

--- a/spec/factories/adyen_notification.rb
+++ b/spec/factories/adyen_notification.rb
@@ -21,6 +21,12 @@ FactoryGirl.define do
        payment nil
      end
 
+     before(:create) do |record, evaluator|
+       if evaluator.payment
+         record.merchant_reference = evaluator.payment.order.number
+       end
+     end
+
      trait :normal_event do
        before(:create) do |record, evaluator|
          if evaluator.payment

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -1,7 +1,0 @@
-FactoryGirl.define do
-  factory :hpp_payment, parent: :payment do
-    association :payment_method, factory: :hpp_gateway
-    association :source, factory: :hpp_source
-    order
-  end
-end

--- a/spec/factories/spree_gateway_adyen_hpp_bogus.rb
+++ b/spec/factories/spree_gateway_adyen_hpp_bogus.rb
@@ -1,0 +1,26 @@
+FactoryGirl.define do
+  factory(
+    :spree_gateway_adyen_hpp_bogus,
+    aliases: ["bogus_hpp_gateway"],
+    class: "Spree::Gateway::AdyenHPPBogus"
+  ) do
+
+    name "Bogus Adyen HPP Gateway"
+    preferred_success true
+    environment "test"
+    preferences(
+      skin_code: 'XXXXX',
+      shared_secret: '1234',
+      merchant_account: 'XXXX',
+      days_to_ship: 3
+    )
+
+    trait :forced_success do
+      preferred_success true
+    end
+
+    trait :forced_failure do
+      preferred_success false
+    end
+  end
+end

--- a/spec/factories/spree_payment.rb
+++ b/spec/factories/spree_payment.rb
@@ -1,0 +1,19 @@
+FactoryGirl.define do
+  factory :hpp_payment, parent: :payment do
+    association :payment_method, factory: :hpp_gateway
+    association :source, factory: :hpp_source
+    order
+  end
+
+  factory :bogus_hpp_payment, parent: :payment do
+    association :payment_method, factory: :bogus_hpp_gateway
+    association :source, factory: :hpp_source
+    order
+
+    before :create do |record, evaluator|
+      # these associations/keys are awful and are making this difficult
+      record.source.order = record.order
+      record.source.merchant_reference = record.order.number
+    end
+  end
+end

--- a/spec/lib/spree/adyen/form_spec.rb
+++ b/spec/lib/spree/adyen/form_spec.rb
@@ -166,8 +166,8 @@ RSpec.describe Spree::Adyen::Form do
 
   describe "details_url" do
     let(:brand_code) { "paypal" }
-    subject { 
-      described_class.details_url(order, payment_method, brand_code) 
+    subject {
+      described_class.details_url(order, payment_method, brand_code)
     }
 
     it "calls endpoint url with the expected params" do
@@ -180,14 +180,14 @@ RSpec.describe Spree::Adyen::Form do
   describe "details_url_with_issuer" do
     let(:issuer_id) { "1654" }
     let(:brand_code) { "paypal" }
-    
-    subject { 
+
+    subject {
       described_class.details_url_with_issuer(
         order,
         payment_method,
         brand_code,
         issuer_id
-      ) 
+      )
     }
 
     it "calls endpoint url with the expected params" do

--- a/spec/lib/spree/adyen/form_spec.rb
+++ b/spec/lib/spree/adyen/form_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Spree::Adyen::Form do
-  let(:order) { create :order, total: 99.0 }
+  let(:order) { create :order, total: 39.98 }
   let(:payment_method) { create :hpp_gateway, preferences: preferences }
   let(:preferences){
     {server: "test",
@@ -26,7 +26,7 @@ RSpec.describe Spree::Adyen::Form do
         skin_code: payment_method.skin_code,
         shared_secret: payment_method.shared_secret,
         country_code: order.billing_address.country.iso,
-        payment_amount: (order.total.to_f * 100).to_int }
+        payment_amount: 3998 }
 
        ::Adyen::Form.redirect_url(redirect_params)
     end

--- a/spec/lib/spree/adyen/payment_spec.rb
+++ b/spec/lib/spree/adyen/payment_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe Spree::Adyen::Payment do
+  describe "adyen_hpp_capture!" do
+    subject { payment.adyen_hpp_capture! }
+
+    let(:payment) { create :payment }
+    let(:am_response) { create :am_response, :success }
+
+    before do
+      expect(payment.payment_method).to receive(:capture).
+        and_return(am_response)
+    end
+
+    it "dispatchs the capture" do
+      expect{ subject }.to change{ payment.log_entries.count }.by(1)
+    end
+
+    it "changes payment state to processing" do
+      expect{ subject }.to change{ payment.state }.to("processing")
+    end
+
+    context "when the capture dispatch fails" do
+      let(:am_response) do
+        create :am_response, :failure, message: "Expected message"
+      end
+
+      it "changes payment state to failed" do
+        expect{ subject }.
+          to change{ payment.state }.to("failed").
+
+          and raise_error(
+            Spree::Core::GatewayError, "Expected message")
+      end
+    end
+  end
+end

--- a/spec/lib/spree/adyen/payment_spec.rb
+++ b/spec/lib/spree/adyen/payment_spec.rb
@@ -1,18 +1,17 @@
 require "spec_helper"
 
 describe Spree::Adyen::Payment do
-  describe "adyen_hpp_capture!" do
-    subject { payment.adyen_hpp_capture! }
+  let(:payment) { create :payment }
 
-    let(:payment) { create :payment }
+  shared_examples "gateway action" do |action|
     let(:am_response) { create :am_response, :success }
 
     before do
-      expect(payment.payment_method).to receive(:capture).
+      expect(payment.payment_method).to receive(action).
         and_return(am_response)
     end
 
-    it "dispatchs the capture" do
+    it "logs the response" do
       expect{ subject }.to change{ payment.log_entries.count }.by(1)
     end
 
@@ -33,5 +32,17 @@ describe Spree::Adyen::Payment do
             Spree::Core::GatewayError, "Expected message")
       end
     end
+  end
+
+  describe "adyen_hpp_cancel!" do
+    subject { payment.adyen_hpp_cancel! }
+    include_examples "gateway action", :cancel
+  end
+
+  describe "adyen_hpp_capture!" do
+    subject { payment.adyen_hpp_capture! }
+
+    let(:payment) { create :payment }
+    include_examples "gateway action", :capture
   end
 end

--- a/spec/models/adyen_notification_spec.rb
+++ b/spec/models/adyen_notification_spec.rb
@@ -5,6 +5,28 @@ RSpec.describe AdyenNotification do
   it { is_expected.to belong_to(:prev).inverse_of(:next) }
   it { is_expected.to belong_to :order }
 
+  describe ".payment" do
+    subject { notification.payment }
+
+    let(:ref) { "999999999" }
+    let!(:payment) { create :payment, response_code: ref }
+    let!(:notification) { described_class.new attr => ref }
+
+    shared_examples "finds the payment" do
+      it { is_expected.to eq payment }
+    end
+
+    context "normal notification" do
+      let(:attr) { :original_reference }
+      include_examples "finds the payment"
+    end
+
+    context "modification notification" do
+      let(:attr) { :psp_reference }
+      include_examples "finds the payment"
+    end
+  end
+
   describe "#build" do
     subject { described_class.build params }
 

--- a/spec/models/adyen_notification_spec.rb
+++ b/spec/models/adyen_notification_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe AdyenNotification do
   it { is_expected.to have_many(:next).inverse_of(:prev) }
@@ -58,7 +58,7 @@ RSpec.describe AdyenNotification do
           merchant_account_code: "Test",
           merchant_reference: "R999999999",
           operations: "CANCEL,CAPTURE,REFUND",
-          original_reference: "",
+          original_reference: nil,
           payment_method: "visa",
           psp_reference: "999999999",
           reason: "41061:1111:6/2016",

--- a/spec/models/spree/adyen/hpp_source_spec.rb
+++ b/spec/models/spree/adyen/hpp_source_spec.rb
@@ -48,4 +48,23 @@ RSpec.describe Spree::Adyen::HppSource do
       it { is_expected.to be false }
     end
   end
+
+  describe ".authorised?" do
+    subject { described_class.new(auth_result: event).authorised? }
+
+    context "when pending" do
+      let(:event) { "PENDING" }
+      it { is_expected.to be true }
+    end
+
+    context "when authorised" do
+      let(:event) { "AUTHORISED" }
+      it { is_expected.to be true }
+    end
+
+    context "when something else" do
+      let(:event) { "REFUSED" }
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/spree/adyen/hpp_source_spec.rb
+++ b/spec/models/spree/adyen/hpp_source_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe Spree::Adyen::HppSource do
   let(:hpp_source) do
     create :hpp_source,
       psp_reference: "999999999",
-      merchant_reference: "R11111111"
+      merchant_reference: "R11111111",
+      payment: create(:bogus_hpp_payment)
   end
 
   describe ".actions" do
+    subject { hpp_source.actions }
     let!(:notification) do
       create(
         :notification,
@@ -27,9 +29,23 @@ RSpec.describe Spree::Adyen::HppSource do
     it { expect(hpp_source.actions).
          to eq %w{adyen_hpp_capture adyen_hpp_refund} }
 
-    context "when it has not auth notification" do
+    shared_examples "has no actions" do
+      it { is_expected.to eq [] }
+    end
+
+    context "when it has no auth notification" do
       let!(:notification) { nil }
-      it { expect(hpp_source.actions).to eq [] }
+      include_examples "has no actions"
+    end
+
+    context "when the payment is void" do
+      before { hpp_source.payment.void }
+      include_examples "has no actions"
+    end
+
+    context "when the payment is still proccesing" do
+      before { hpp_source.payment.started_processing! }
+      include_examples "has no actions"
     end
   end
 

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -122,6 +122,21 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
       include_examples "completes payment"
     end
 
+    context "when event is CANCEL_OR_REFUND" do
+      let(:event_type) { :cancel_or_refund }
+
+      before do
+        payment.complete
+      end
+
+      it "voids the payment" do
+        expect { subject }.
+          to change { payment.reload.state }.
+          from("completed").
+          to("void")
+      end
+    end
+
     context "when the event is an event we don't process" do
       let(:event_type) { :pending }
       include_examples "returns the notification"

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Spree::Adyen::NotificationProcessing do
+RSpec.describe Spree::Adyen::NotificationProcessor do
   describe "#find_payment" do
     subject { described_class.find_payment notification }
 
@@ -36,7 +36,7 @@ RSpec.describe Spree::Adyen::NotificationProcessing do
     subject { described_class.process(notification)}
 
     before do
-      allow(Spree::Adyen::NotificationProcessing).to(
+      allow(Spree::Adyen::NotificationProcessor).to(
         receive(:find_payment).with(notification).and_return(payment)
       )
     end

--- a/spec/models/spree/gateway/adyen_hpp_spec.rb
+++ b/spec/models/spree/gateway/adyen_hpp_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 module Spree
   describe Gateway::AdyenHPP do
+    let(:hpp_source) { create :hpp_source, psp_reference: "9999" }
+    let(:gateway) { described_class.new }
+
     describe ".capture" do
       subject do
         gateway.capture(2000, hpp_source, currency: "CAD")
       end
-
-      let(:hpp_source) { create :hpp_source, psp_reference: "9999" }
-      let(:gateway) { described_class.new }
 
       let(:response) do
         instance_double(
@@ -41,6 +41,11 @@ module Spree
           expect(subject.void("huhu").authorization).to eq "huhu"
         end
       end
+    end
+
+    describe ".authorize" do
+      subject { gateway.authorize 2000, hpp_source, currency: "CAD" }
+      it { is_expected.to be_a ActiveMerchant::Billing::Response }
     end
 
     context "calculate ship_before_date" do

--- a/spec/models/spree/gateway/adyen_hpp_spec.rb
+++ b/spec/models/spree/gateway/adyen_hpp_spec.rb
@@ -7,7 +7,7 @@ module Spree
 
     describe ".capture" do
       subject do
-        gateway.capture(2000, hpp_source, currency: "CAD")
+        gateway.capture(2000, hpp_source.psp_reference, currency: "CAD")
       end
 
       let(:response) do

--- a/spec/models/spree/gateway/adyen_hpp_spec.rb
+++ b/spec/models/spree/gateway/adyen_hpp_spec.rb
@@ -3,6 +3,13 @@ require 'spec_helper'
 module Spree
   describe Gateway::AdyenHPP do
     describe ".capture" do
+      subject do
+        gateway.capture(2000, hpp_source, currency: "CAD")
+      end
+
+      let(:hpp_source) { create :hpp_source, psp_reference: "9999" }
+      let(:gateway) { described_class.new }
+
       let(:response) do
         instance_double(
           ::Adyen::API::PaymentService::CaptureResponse,
@@ -14,13 +21,14 @@ module Spree
         )
       end
 
-      it "makes an api call" do
-        expect(subject.provider_class).
+      it "makes an api call the returns the orginal psp ref as an authorization" do
+        expect(gateway.provider_class).
           to receive(:capture_payment).
           and_return(response)
 
-        expect(subject.capture(2000, "1234", currency: "CAD")).
-          to be_a ::ActiveMerchant::Billing::Response
+        expect(subject).to be_a ::ActiveMerchant::Billing::Response
+
+        expect(subject.authorization).to eq "9999"
       end
     end
 

--- a/spec/models/spree/gateway/adyen_hpp_spec.rb
+++ b/spec/models/spree/gateway/adyen_hpp_spec.rb
@@ -24,6 +24,7 @@ module Spree
       it "makes an api call the returns the orginal psp ref as an authorization" do
         expect(gateway.provider_class).
           to receive(:capture_payment).
+          with("9999", {currency: "CAD", value: 2000}).
           and_return(response)
 
         expect(subject).to be_a ::ActiveMerchant::Billing::Response


### PR DESCRIPTION
Adds support for cancellations on payments. Internally it calls Adyen's cancel_or_refund end point so it doesn't matter what the original state of the payment was.  
