### PR TITLE
Paritial Refunds

### DIFF
--- a/app/controllers/spree/admin/refunds_controller_decorator.rb
+++ b/app/controllers/spree/admin/refunds_controller_decorator.rb
@@ -1,0 +1,49 @@
+Spree::Admin::RefundsController.class_eval do
+  before_filter :adyen_create, only: [:create]
+
+  def adyen_create
+    if hpp_payment?
+      # this sucks, but the attributes are not assigned until after callbacks
+      # if we're here we aren't going down the normal flow anyways
+      @refund.attributes = permitted_resource_params
+
+      # early exit if @refund is invalid, .create will have the error messages
+      return if @refund.invalid?
+
+      @payment.refunds.reset # we don't want to save the refund
+      @payment.adyen_hpp_credit!(cents, currency: currency)
+
+      respond
+    end
+  end
+
+  private
+
+  def currency
+    money.currency.iso_code
+  end
+
+  def cents
+    money.cents
+  end
+
+  def money
+    @refund.money.money
+  end
+
+  def hpp_payment?
+    @refund.payment.source.class == Spree::Adyen::HppSource
+  end
+
+  # This is directly copied from .create's response, no way to make it any
+  # less awful than this as we still want it to have the same response.
+  def respond
+    respond_with(@object) do |format|
+      format.html do
+        flash[:success] = "Refund request was received"
+        redirect_to location_after_save
+      end
+      format.js { render :layout => false }
+    end
+  end
+end

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -95,6 +95,10 @@ class AdyenNotification < ActiveRecord::Base
     event_code == CANCEL_OR_REFUND
   end
 
+  def refund?
+    event_code == REFUND
+  end
+
   def actions
     if operations
       operations.

--- a/app/models/spree/adyen/hpp_source.rb
+++ b/app/models/spree/adyen/hpp_source.rb
@@ -61,11 +61,27 @@ class Spree::Adyen::HppSource < ActiveRecord::Base
 
   # authorised_actions :: [String] | []
   def authorised_actions
-    notifications.
-      processed.
-      authorisation.
-      last.
-      try { actions }.
-      try { map { |action| "adyen_hpp_#{action}" } } || []
+    if auth_notification
+      auth_notification.
+        actions.map(&method(:transform_action))
+
+    else
+      []
+
+    end
+  end
+
+  def transform_action action
+    if action == "refund"
+      # return credit so that we go to the new refund action
+      "credit"
+    else
+      # call custom payment actions
+      "adyen_hpp_#{action}"
+    end
+  end
+
+  def auth_notification
+    notifications.processed.authorisation.last
   end
 end

--- a/app/models/spree/adyen/hpp_source.rb
+++ b/app/models/spree/adyen/hpp_source.rb
@@ -48,6 +48,10 @@ class Spree::Adyen::HppSource < ActiveRecord::Base
     end
   end
 
+  def can_adyen_hpp_cancel? payment
+    payment.refunds.empty?
+  end
+
   def authorised?
     # Many banks return pending, this is considered a valid response and
     # the order should proceed.

--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -76,6 +76,15 @@ class Spree::Adyen::NotificationProcessor
     elsif notification.cancel_or_refund?
       payment.void
 
+    elsif notification.refund?
+      payment.refunds.create!(
+        amount: notification.value / 100, # cents to dollars
+        transaction_id: notification.psp_reference,
+        refund_reason_id: Spree::RefundReason.first.id # FIXME
+      )
+      # payment was processing, move back to completed
+      payment.complete!
+
     end
   end
 

--- a/app/models/spree/gateway/adyen_hpp.rb
+++ b/app/models/spree/gateway/adyen_hpp.rb
@@ -65,21 +65,12 @@ module Spree
         psp_reference)
     end
 
-    def credit(credit_cents, transaction_id, gateway_options = {})
-      currency = gateway_options[:currency]
-      currency ||= gateway_options[:originator].payment.currency
-      amount = { currency: currency, value: credit_cents }
-      response = provider.refund_payment transaction_id, amount
+    def credit(amount, psp_reference, currency:, **_opts)
+      amount = { currency: currency, value: amount }
 
-      if response.success?
-        def response.authorization; psp_reference; end
-      else
-        def response.to_s
-          refusal_reason
-        end
-      end
-
-      response
+      handle_response(
+        provider.refund_payment(psp_reference, amount),
+        psp_reference)
     end
 
     private

--- a/app/models/spree/gateway/adyen_hpp.rb
+++ b/app/models/spree/gateway/adyen_hpp.rb
@@ -87,10 +87,18 @@ module Spree
     def handle_response response, original_reference
       ActiveMerchant::Billing::Response.new(
         response.success?,
-        JSON.pretty_generate(response.params),
+        message(response),
         {},
         authorization: original_reference
       )
+    end
+
+    def message response
+      if response.success?
+        JSON.pretty_generate(response.params)
+      else
+        response.fault_message
+      end
     end
   end
 end

--- a/lib/spree/adyen/payment.rb
+++ b/lib/spree/adyen/payment.rb
@@ -12,6 +12,9 @@ module Spree::Adyen::Payment
   end
 
   # adyen_hpp_credit! :: bool | error
+  #
+  # Issue a request to credit the payment, this does NOT perform validation on
+  # the amount to be credited, which is assumed to have been done prior to this.
   def adyen_hpp_credit! amount, options
     started_processing!
     response = payment_method.credit(amount, response_code, options)

--- a/lib/spree/adyen/payment.rb
+++ b/lib/spree/adyen/payment.rb
@@ -11,9 +11,22 @@ module Spree::Adyen::Payment
     gateway_action(response_code, :capture, :started_processing)
   end
 
-  # adyen_hpp_refund! :: bool | error
-  def adyen_hpp_refund!
-    raise NotImplementedError
+  # adyen_hpp_credit! :: bool | error
+  def adyen_hpp_credit! amount, options
+    started_processing!
+    response = payment_method.credit(amount, response_code, options)
+    record_response(response)
+
+    if response.success?
+      # The payments controller's fire action expects a truthy value to
+      # indicate success
+      true
+    else
+      # this is done to be consistent with capture, but we might actually
+      # want them to just return to the previous state
+      self.failure
+      gateway_error(response)
+    end
   end
 
   # adyen_hpp_cancel! :: bool | error

--- a/lib/spree/adyen/payment.rb
+++ b/lib/spree/adyen/payment.rb
@@ -5,10 +5,10 @@
 module Spree::Adyen::Payment
   # adyen_hpp_capture! :: bool | error
   def adyen_hpp_capture!
-    started_processing!
-    # success state must remain as processing, it will change to completed
-    # once the notification is received
-    gateway_action(response_code, :capture, :started_processing)
+    amount = money.money.cents
+    process do
+      payment_method.send(:capture, amount, response_code, gateway_options)
+    end
   end
 
   # adyen_hpp_credit! :: bool | error
@@ -16,20 +16,7 @@ module Spree::Adyen::Payment
   # Issue a request to credit the payment, this does NOT perform validation on
   # the amount to be credited, which is assumed to have been done prior to this.
   def adyen_hpp_credit! amount, options
-    started_processing!
-    response = payment_method.credit(amount, response_code, options)
-    record_response(response)
-
-    if response.success?
-      # The payments controller's fire action expects a truthy value to
-      # indicate success
-      true
-    else
-      # this is done to be consistent with capture, but we might actually
-      # want them to just return to the previous state
-      self.failure
-      gateway_error(response)
-    end
+    process { payment_method.credit(amount, response_code, options) }
   end
 
   # adyen_hpp_cancel! :: bool | error
@@ -37,9 +24,23 @@ module Spree::Adyen::Payment
   # Borrowed from handle_void_response, this has been modified so that it won't
   # actually void the payment _yet_.
   def adyen_hpp_cancel!
-    started_processing!
+    process { payment_method.cancel response_code }
+  end
 
-    response = payment_method.cancel response_code
+  private
+
+  def process &block
+    check_environment
+    response = nil
+
+    Spree::Payment.transaction do
+      protect_from_connection_error do
+        started_processing!
+        response = yield(block)
+        raise ActiveRecord::Rollback unless response.success?
+      end
+    end
+
     record_response(response)
 
     if response.success?
@@ -49,7 +50,6 @@ module Spree::Adyen::Payment
     else
       # this is done to be consistent with capture, but we might actually
       # want them to just return to the previous state
-      self.failure
       gateway_error(response)
     end
   end

--- a/spec/controllers/spree/admin/refunds_controller_spec.rb
+++ b/spec/controllers/spree/admin/refunds_controller_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+
+RSpec.describe Spree::Admin::RefundsController do
+  stub_authorization!
+  include_context "mock adyen api", success: true
+  routes { Spree::Core::Engine.routes }
+
+  describe "POST create" do
+    subject { post :create, params }
+
+    let(:params) do
+      {
+        "refund" => {
+          "amount" => amount,
+          "refund_reason_id" => reason.id
+        },
+        "order_id" => order.number,
+        "payment_id" => payment.id
+      }
+    end
+
+    let(:reason) { create :refund_reason }
+    let(:order) { create :order, currency: "EUR" }
+    let(:amount) { 100.0 }
+    let(:payment_opts) { {state: "completed", amount: 100.0} }
+
+    before do
+      payment.capture_events.create!(amount: 100.0)
+    end
+
+    context "when the payment comes from Adyen Hosted Payment Pages" do
+      let(:payment) { create :hpp_payment, order: order, **payment_opts }
+
+      it "does not create the record" do
+        expect { subject }.to_not change { payment.reload.refunds.count }
+      end
+
+      it "sets the success flash" do
+        subject
+        expect(flash[:success]).to eq "Refund request was received"
+      end
+
+      it "requests the refund" do
+        expect_any_instance_of(Spree::Payment).
+          to receive(:adyen_hpp_credit!).
+          with(10000, currency: "EUR")
+        subject
+      end
+
+      it { is_expected.to have_http_status :redirect }
+
+      context "and the refund is invalid" do
+        let(:amount) { 0 }
+
+        it "displays an error" do
+          is_expected.to have_http_status :ok
+          expect(flash[:error]).to be_present
+        end
+
+        it "doesn't attempt to credit the payment" do
+          expect_any_instance_of(Spree::Payment).
+            to_not receive(:adyen_hpp_credit!)
+          subject
+        end
+      end
+    end
+
+    context "when any other kind of payment" do
+      let(:payment) { create :payment, **payment_opts }
+
+      it "creates the refund" do
+        expect { subject }.to change { payment.reload.refunds.count }.by(1)
+      end
+    end
+  end
+end

--- a/spec/lib/spree/adyen/payment_spec.rb
+++ b/spec/lib/spree/adyen/payment_spec.rb
@@ -1,28 +1,26 @@
 require "spec_helper"
 
 describe Spree::Adyen::Payment do
-  let(:payment) { create :payment }
+  let(:payment) { create :hpp_payment }
 
-  shared_examples "gateway action" do |action|
-    let(:am_response) { create :am_response, :success }
+  shared_examples "gateway action" do
+    context "when the action succeeds" do
+      include_context "mock adyen api", success: true
 
-    before do
-      expect(payment.payment_method).to receive(action).
-        and_return(am_response)
-    end
-
-    it "logs the response" do
-      expect{ subject }.to change{ payment.log_entries.count }.by(1)
-    end
-
-    it "changes payment state to processing" do
-      expect{ subject }.to change{ payment.state }.to("processing")
-    end
-
-    context "when the capture dispatch fails" do
-      let(:am_response) do
-        create :am_response, :failure, message: "Expected message"
+      it "logs the response" do
+        expect{ subject }.to change{ payment.log_entries.count }.by(1)
       end
+
+      it "changes payment state to processing" do
+        expect{ subject }.to change{ payment.state }.to("processing")
+      end
+    end
+
+    context "when the action fails" do
+      include_context(
+        "mock adyen api",
+        success: false,
+        fault_message: "Expected message")
 
       it "changes payment state to failed" do
         expect{ subject }.
@@ -36,13 +34,16 @@ describe Spree::Adyen::Payment do
 
   describe "adyen_hpp_cancel!" do
     subject { payment.adyen_hpp_cancel! }
-    include_examples "gateway action", :cancel
+    include_examples "gateway action"
   end
 
   describe "adyen_hpp_capture!" do
     subject { payment.adyen_hpp_capture! }
+    include_examples "gateway action"
+  end
 
-    let(:payment) { create :payment }
-    include_examples "gateway action", :capture
+  describe "adyen_hpp_credit!" do
+    subject { payment.adyen_hpp_credit! "1000", currency: "EUR" }
+    include_examples "gateway action"
   end
 end

--- a/spec/models/spree/adyen/hpp_source_spec.rb
+++ b/spec/models/spree/adyen/hpp_source_spec.rb
@@ -85,4 +85,17 @@ RSpec.describe Spree::Adyen::HppSource do
       it { is_expected.to be false }
     end
   end
+
+  describe ".can_adyen_hpp_cancel?" do
+    subject { hpp_source.can_adyen_hpp_cancel? hpp_source.payment }
+
+    context "when the payment has refunds" do
+      before { create :refund, amount: 1, payment: hpp_source.payment }
+      it { is_expected.to be false }
+    end
+
+    context "when the payment doesn't have refunds" do
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/models/spree/adyen/hpp_source_spec.rb
+++ b/spec/models/spree/adyen/hpp_source_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Spree::Adyen::HppSource do
 
     it { expect(hpp_source.notifications.count).to eq 1 }
     it { expect(hpp_source.actions).
-         to eq %w{adyen_hpp_capture adyen_hpp_refund} }
+         to eq %w{adyen_hpp_capture credit} }
 
     shared_examples "has no actions" do
       it { is_expected.to eq [] }

--- a/spec/models/spree/gateway/adyen_hpp_spec.rb
+++ b/spec/models/spree/gateway/adyen_hpp_spec.rb
@@ -8,13 +8,15 @@ module Spree
 
     include_context "mock adyen api", success: true
 
-    describe ".capture" do
-      subject { gateway.capture(2000, "9999", currency: "CAD") }
+    shared_examples "delayed gateway action" do
+      context "when the action succeeds" do
+        include_context "mock adyen api", success: true
 
-      it "makes an api call the returns the orginal psp ref as an authorization" do
-        expect(subject).to be_a ::ActiveMerchant::Billing::Response
+        it { is_expected.to be_a ::ActiveMerchant::Billing::Response }
 
-        expect(subject.authorization).to eq "9999"
+        it "returns the orginal psp ref as an authorization" do
+          expect(subject.authorization).to eq "9999"
+        end
       end
 
       context "when the action fails" do
@@ -30,8 +32,23 @@ module Spree
       end
     end
 
+    describe ".capture" do
+      subject { gateway.capture(2000, "9999", currency: "EUR") }
+      include_examples "delayed gateway action"
+    end
+
+    describe ".credit" do
+      subject { gateway.credit(2000, "9999", currency: "EUR") }
+      include_examples "delayed gateway action"
+    end
+
+    describe ".cancel" do
+      subject { gateway.cancel("9999") }
+      include_examples "delayed gateway action"
+    end
+
     describe ".authorize" do
-      subject { gateway.authorize 2000, hpp_source, currency: "CAD" }
+      subject { gateway.authorize 2000, hpp_source, currency: "EUR" }
       it { is_expected.to be_a ActiveMerchant::Billing::Response }
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,8 @@ module Spree
 end
 
 RSpec.configure do |config|
+  RSpec::Matchers.define_negated_matcher :keep, :change
+
   config.color = true
   config.infer_spec_type_from_file_location!
   config.mock_with :rspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ require 'spree/testing_support/factories'
 require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/url_helpers'
 require "support/shared_contexts/mock_adyen_api"
+require "spree/testing_support/authorization_helpers"
 
 FactoryGirl.definition_file_paths = %w{./spec/factories}
 FactoryGirl.find_definitions


### PR DESCRIPTION
Adds support for partial refunds on hpp payments. 
Also, api failures do not fail the payment now (see last commit message for explanation).
