### PR TITLE
Fix issue with early notifications

### DIFF
--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -26,11 +26,11 @@ module Spree
           state: "checkout"
         )
 
-      # We may have already recieved the authorization notification, so process
-      # it now
-      Spree::Adyen::NotificationProcessor.process_outstanding!(payment)
-
       if current_order.complete
+        # We may have already recieved the authorization notification, so process
+        # it now
+        Spree::Adyen::NotificationProcessor.process_outstanding!(payment)
+
         flash.notice = Spree.t(:current_order_processed_successfully)
         redirect_to order_path(current_order)
       else


### PR DESCRIPTION
Currently checkout is broken if Adyen responds to an authorization before the redirect occurs.

When `process_outstanding` is called, if there is already a authorization notification for a bank payment it completes the payment (from checkout -> completed states) - but this is prior to the order completing.

The order statemachine has a prerequisite transition event from `payment` -> `completed` called `process_paymnets_before_complete` which will call authorize on all payment in checkout state, or purchase if autocapture is enabled.

The problem arises when process_payment prevents transition to completed when there are no payments in checkout state
