### PR TITLE
Fix issues with Sofort payment method

### DIFF
--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -23,7 +23,18 @@ module Spree
           payment_method: payment_method,
           source: source,
           response_code: params[:pspReference],
-          state: "checkout"
+          state: "checkout",
+          # Order is explicitly defined here because as of writing the
+          # Order -> Payments association does not have the inverse of defined
+          # when we call `current_order.complete` below payment.order will still
+          # refer to a previous state of the record.
+          #
+          # If the payment is auto captured only then the payment will completed
+          # in `process_outstanding!`, and because Payment calls
+          # .order.update_totals after save the order is saved with its
+          # previous values, causing payment_state and shipment_state to revert
+          # to nil.
+          order: current_order
         )
 
       if current_order.complete

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -96,9 +96,15 @@ class AdyenNotification < ActiveRecord::Base
   end
 
   def actions
-    self.operations.
-      split(",").
-      map(&:downcase)
+    if operations
+      operations.
+        split(",").
+        map(&:downcase)
+
+    else
+      []
+
+    end
   end
 
   # https://docs.adyen.com/display/TD/Notification+fields

--- a/spec/factories/adyen_notification.rb
+++ b/spec/factories/adyen_notification.rb
@@ -50,6 +50,14 @@ FactoryGirl.define do
        reason "31893:0002:8/2018"
      end
 
+     trait :sofort_auth do
+       auth
+       event_code "AUTHORISATION"
+       payment_method "directEbanking"
+       operations nil
+       reason nil
+     end
+
      trait :bank_auth do
        auth
        operations "REFUND"

--- a/spec/models/adyen_notification_spec.rb
+++ b/spec/models/adyen_notification_spec.rb
@@ -67,4 +67,20 @@ RSpec.describe AdyenNotification do
         )
     end
   end
+
+  describe ".actions" do
+    subject { notification.actions }
+    let(:notification) { create :notification, :auth, operations: operations }
+
+    context "when the notification has operations" do
+      let(:operations) { "CAPTURE,REFUND,CANCEL_OR_REFUND" }
+
+      it { is_expected.to eq ["capture", "refund", "cancel_or_refund"] }
+    end
+
+    context "when the notification's operations are nil" do
+      let(:operations) { nil }
+      it { is_expected.to eq [] }
+    end
+  end
 end

--- a/spec/support/shared_contexts/mock_adyen_api.rb
+++ b/spec/support/shared_contexts/mock_adyen_api.rb
@@ -1,0 +1,50 @@
+shared_context "mock adyen api" do |success:, fault_message: "", psp_reference: ""|
+  before do
+    allow_any_instance_of(Spree::Gateway::AdyenHPP).
+      to receive(:provider).
+      and_return provider
+  end
+
+  let(:provider) do
+    mock_response = -> (method) {
+      response(method, success, fault_message, psp_reference)
+    }
+
+    instance_double("Adyen::API").tap do |double|
+      allow(double).
+        to receive(:capture_payment).
+        with(
+          kind_of(String),
+          hash_including(:currency, :value)
+        ).
+        and_return(mock_response.("capture"))
+
+      allow(double).
+        to receive(:cancel_or_refund_payment).
+        with(kind_of(String)).
+        and_return(mock_response.("cancel_or_refund"))
+
+      allow(double).
+        to receive(:refund_payment).
+        with(
+          kind_of(String),
+          hash_including(:currency, :value)
+        ).
+        and_return(mock_response.("refund"))
+    end
+  end
+
+  def response(method, success, fault_message, ref = nil)
+    ref ||= "%016d" % SecureRandom.random_number(10**16)
+
+    instance_double(
+      "Adyen::API::PaymentService::#{method.camelcase}Response",
+      success?: success,
+      fault_message: fault_message,
+      params: {
+        psp_reference: ref,
+        response: "[#{method.camelcase(:lower)}-received]"
+      }
+    )
+  end
+end


### PR DESCRIPTION
Fixes an awful bug where autocapture only payment's loose their order's payment and shipment state after confirmation.

> There was a bug where auto capture only payment methods were causing
> completed orders to have a nil payment and shipping state.
> 
> Order is explicitly defined here because as of writing the Order ->
> Payments association does not have the inverse of defined when we call
> `current_order.complete` below payment.order will still refer to a
> previous state of the record.
> 
> If the payment is auto captured only then the payment will completed in
> `process_outstanding!`, and because Payment calls .order.update_totals
> after save the order is saved with its previous values, causing
> payment_state and shipment_state to revert to nil.
