### PR TITLE
Fix notifications not saving on error

### DIFF
--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -12,12 +12,8 @@ class Spree::AdyenNotificationsController < Spree::StoreController
 
     notification.save!
 
-    begin
-      Spree::Adyen::NotificationProcessor.new(notification).process!
-    ensure
-      # must accept notification, but still bubble error
-      accept
-    end
+    Spree::Adyen::NotificationProcessor.new(notification).process!
+    accept
   end
 
   protected

--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -10,10 +10,14 @@ class Spree::AdyenNotificationsController < Spree::StoreController
       accept and return
     end
 
-    Spree::Adyen::NotificationProcessor.new(notification).process!
+    notification.save!
 
-    # accept after processing has completed
-    accept
+    begin
+      Spree::Adyen::NotificationProcessor.new(notification).process!
+    ensure
+      # must accept notification, but still bubble error
+      accept
+    end
   end
 
   protected

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -100,7 +100,7 @@ class AdyenNotification < ActiveRecord::Base
   end
 
   def processed!
-    update processed: true
+    update! processed: true
   end
 
   def actions

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -99,6 +99,10 @@ class AdyenNotification < ActiveRecord::Base
     event_code == REFUND
   end
 
+  def processed!
+    update processed: true
+  end
+
   def actions
     if operations
       operations.

--- a/spec/controllers/spree/adyen_notifications_controller_spec.rb
+++ b/spec/controllers/spree/adyen_notifications_controller_spec.rb
@@ -63,6 +63,21 @@ describe Spree::AdyenNotificationsController do
         let(:payment) { nil }
         include_examples "logs the notification"
       end
+
+      # regression test
+      context "an error occurs during processing" do
+        before { payment.void! }
+        before { params["success"] = false }
+
+        it "errors and creates a notification" do
+          expect { subject }.
+            to raise_error(StateMachines::InvalidTransition).
+            and change { AdyenNotification.count }.by(1)
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to have_content "[accepted]"
+        end
+      end
     end
 
     context "request not authenticated" do


### PR DESCRIPTION
Fixes an issue where notifications were not saving if an error occurred during
processing. Common cause to this issue was that an invalid statemachine transition
was triggered. Fix for that coming next.
