### PR TITLE
Better support for manual refunds

### DIFF
--- a/app/assets/stylesheets/spree/backend/solidus-adyen.css
+++ b/app/assets/stylesheets/spree/backend/solidus-adyen.css
@@ -1,3 +1,4 @@
 /*
  *= require spree/backend
+ *= require spree/backend/solidus-adyen/buttons
  */

--- a/app/assets/stylesheets/spree/backend/solidus-adyen/buttons.scss
+++ b/app/assets/stylesheets/spree/backend/solidus-adyen/buttons.scss
@@ -1,0 +1,15 @@
+@import 'variables';
+
+.button-error {
+  background-color: $color-error;
+
+  &.fa:before {
+    color: $color-warning;
+  }
+  &:hover {
+    background-color: lighten($color-error, 5%);
+  }
+  &:active {
+    background-color: darken($color-error, 5%);
+  }
+}

--- a/app/assets/stylesheets/spree/backend/solidus-adyen/variables.scss
+++ b/app/assets/stylesheets/spree/backend/solidus-adyen/variables.scss
@@ -1,0 +1,4 @@
+@import 'spree/backend/globals/variables';
+
+$color-safety-yellow: #eed202;
+$color-warning: $color-safety-yellow;

--- a/app/models/concerns/spree/adyen/order.rb
+++ b/app/models/concerns/spree/adyen/order.rb
@@ -1,0 +1,7 @@
+module Spree::Adyen::Order
+  def requires_manual_refund?
+    canceled? && payments.any? do |payment|
+      payment.source.try(:requires_manual_refund?)
+    end
+  end
+end

--- a/app/models/spree/adyen/hpp_source.rb
+++ b/app/models/spree/adyen/hpp_source.rb
@@ -52,6 +52,10 @@ class Spree::Adyen::HppSource < ActiveRecord::Base
     payment.refunds.empty?
   end
 
+  def requires_manual_refund?
+    payment_method == "directEbanking" # aka sofort
+  end
+
   def authorised?
     # Many banks return pending, this is considered a valid response and
     # the order should proceed.

--- a/app/models/spree/adyen/hpp_source.rb
+++ b/app/models/spree/adyen/hpp_source.rb
@@ -8,10 +8,14 @@
 # Information about when certain action are valid:
 # https://docs.adyen.com/display/TD/HPP+modifications
 class Spree::Adyen::HppSource < ActiveRecord::Base
-  PENDING = "PENDING"
-  AUTHORISED = "AUTHORISED"
-  REFUSED = "REFUSED"
-  CANCELLED = "CANCELLED"
+  MANUALLY_REFUNDABLE = [
+    "directEbanking"
+  ].freeze
+
+  PENDING = "PENDING".freeze
+  AUTHORISED = "AUTHORISED".freeze
+  REFUSED = "REFUSED".freeze
+  CANCELLED = "CANCELLED".freeze
 
   # support updates from capital-cased responses, which is what adyen gives us
   alias_attribute :authResult, :auth_result
@@ -53,7 +57,7 @@ class Spree::Adyen::HppSource < ActiveRecord::Base
   end
 
   def requires_manual_refund?
-    payment_method == "directEbanking" # aka sofort
+    MANUALLY_REFUNDABLE.include?(payment_method)
   end
 
   def authorised?

--- a/app/overrides/spree/admin/shared/_order_summary.rb
+++ b/app/overrides/spree/admin/shared/_order_summary.rb
@@ -1,0 +1,6 @@
+Deface::Override.new(
+  virtual_path: "spree/admin/shared/_order_summary",
+  name: "manual-refund-button",
+  insert_before: "#order_tab_summary",
+  partial: "spree/adyen/manual_refund"
+)

--- a/app/views/spree/adyen/_manual_refund.html.erb
+++ b/app/views/spree/adyen/_manual_refund.html.erb
@@ -1,7 +1,7 @@
 <% if @order.requires_manual_refund? %>
   <%=
     link_to(
-      t("solidus-adyen.manual_refund"),
+      t("solidus-adyen.manual_refund.order_button"),
       Spree::Adyen::URL.modify_search_url(query: @order.number),
       class: "fa fa-warning button button-error",
       target: "_blank"

--- a/app/views/spree/adyen/_manual_refund.html.erb
+++ b/app/views/spree/adyen/_manual_refund.html.erb
@@ -1,0 +1,3 @@
+<% if @order.requires_manual_refund? %>
+  <a class="fa fa-warning button button-error">manual refund required</a>
+<% end %>

--- a/app/views/spree/adyen/_manual_refund.html.erb
+++ b/app/views/spree/adyen/_manual_refund.html.erb
@@ -1,3 +1,9 @@
 <% if @order.requires_manual_refund? %>
-  <a class="fa fa-warning button button-error">manual refund required</a>
+  <%=
+    link_to(
+      t("solidus-adyen.manual_refund"),
+      Spree::Adyen::URL.modify_search_url(query: @order.number),
+      class: "fa fa-warning button button-error",
+      target: "_blank"
+    )%>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,4 @@
+---
+en:
+  solidus-adyen:
+    manual_refund: "manual refund required"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,9 @@
 ---
 en:
   solidus-adyen:
-    manual_refund: "manual refund required"
+    manual_refund:
+      order_button: "manual refund required"
+      log_message: A cancellation was attempted on this payment but the payment
+        method only supports manual refunds.
+        Please attempt to refund this payment through the Adyen customer area
+        or contact an Adyen representative to assist.

--- a/lib/spree/adyen/engine.rb
+++ b/lib/spree/adyen/engine.rb
@@ -22,6 +22,7 @@ module Spree
 
       def self.activate
         Spree::Payment.include Spree::Adyen::Payment
+        Spree::Order.include Spree::Adyen::Order
         Spree::Admin::RefundsController.include Spree::Adyen::Admin::RefundsController
       end
 

--- a/lib/spree/adyen/url.rb
+++ b/lib/spree/adyen/url.rb
@@ -10,4 +10,16 @@ module Spree::Adyen::URL
       }.to_query
     ).to_s
   end
+
+  def self.modify_search_url(query:)
+    ::URI::HTTPS.build(
+      host: "ca-test.adyen.com",
+      path: "/ca/ca/payments/modifySearch.shtml",
+      query:
+      { uxEvent: "PAYMENT_SEARCH",
+        query: query,
+        search: "Search"
+      }.to_query
+    ).to_s
+  end
 end

--- a/spec/factories/spree_adyen_hpp_source.rb
+++ b/spec/factories/spree_adyen_hpp_source.rb
@@ -5,6 +5,11 @@ FactoryGirl.define do
     auth_result 'AUTHORISED'
     psp_reference { SecureRandom.hex }
     merchant_sig 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+    payment_method "amex"
     order
+
+    trait :sofort do
+      payment_method "directEbanking"
+    end
   end
 end

--- a/spec/models/concerns/spree/adyen/order_spec.rb
+++ b/spec/models/concerns/spree/adyen/order_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+RSpec.describe Spree::Order do
+  include_context "mock adyen api", success: true
+
+  describe "requires_manual_refund?" do
+    subject { order.requires_manual_refund? }
+
+    let!(:order) { create :order_ready_to_ship }
+
+    it { is_expected.to be false }
+
+    context "when it is cancelled and has a payment that much be manually refunded" do
+      let!(:payment) { create :hpp_payment, order: order, source: source }
+      let(:source) { create :hpp_source, :sofort, order: order }
+
+      before { order.cancel! }
+
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/models/concerns/spree/adyen/payment_spec.rb
+++ b/spec/models/concerns/spree/adyen/payment_spec.rb
@@ -50,6 +50,21 @@ describe Spree::Adyen::Payment do
           to("void")
       end
     end
+
+    context "when payment is only manually refundable" do
+      let(:payment) { create :hpp_payment, source: source }
+      let(:source) { create :hpp_source, :sofort }
+
+      it "creates a log entry" do
+        expect { subject }.
+          to change { payment.reload.log_entries.count }
+      end
+
+      it "doesn't change the state" do
+        expect { subject }.
+          to_not change { payment.reload.state }
+      end
+    end
   end
 
   describe "capture!" do


### PR DESCRIPTION
Don't attempt to cancel payments that don't support it.

Attempting to cancel a payment that only supports manual refunds will not contact the api.

Instead it will keep the payment in the completed state, which in turns causes the order-payment-state to be 'credit owed'. A log entry in created on the payment that has a message about the the manual refund.

![2015-11-03-152039_1025x478_escrotum](https://cloud.githubusercontent.com/assets/3162299/10924814/790eebbc-823e-11e5-91bf-7b267d7d543b.png)
