### PR TITLE
Fix for nil current_order on redirect

### DIFF
--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -14,9 +14,8 @@ module Spree
         return
       end
 
-      order = Spree::Order.find_by(number: params[:merchantReference]) ||
-                current_order ||
-                raise(ActiveRecord::RecordNotFound)
+      order = current_order ||
+                Spree::Order.find_by!(number: params[:merchantReference])
 
       # payment is created in a 'checkout' state so that the payment method
       # can attempt to auth it. The payment of course is already auth'd and


### PR DESCRIPTION
Sometimes we get 404s after successful payments because the user comes back with no cookies, so current_order is nil. We can avoid this because Adyen returns the order number as reference, so we should always try and pick up the order using that, defaulting back to current_order, or erroring if that doesn't work.
