### PR TITLE
Allow merchant reference column to be null.

### DIFF
--- a/db/migrate/20151106093023_allow_merchant_reference_to_be_null_for_adyen_notification.rb
+++ b/db/migrate/20151106093023_allow_merchant_reference_to_be_null_for_adyen_notification.rb
@@ -1,0 +1,5 @@
+class AllowMerchantReferenceToBeNullForAdyenNotification < ActiveRecord::Migration
+  def change
+    change_column :adyen_notifications, :merchant_reference, :string, null: true
+  end
+end


### PR DESCRIPTION
We were getting errors like this:
`ActiveRecord::StatementInvalid: PG::NotNullViolation: ERROR:  null value in column "merchant_reference" violates not-null constraint
DETAIL:  Failing row contains (113, t, REPORT_AVAILABLE, settlement_detail_report_batch_1.csv, null, null, LostmynameNAME0`
due to `merchant_reference` being null. Looking at Adyen's docs https://docs.adyen.com/display/TD/Notification+fields this is perfectly valid, so I'm removing the non-null constraint. At the moment these notifications will attempt to process, not find a payment, then do nothing.

Happy to discuss if we should be doing anything more comprehensive with these rather than just accepting and storing them.
