### PR TITLE
Fix for state machine errors after refunding in Adyen interface

### DIFF
--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -72,7 +72,7 @@ module Spree
             refund_reason_id: ::Spree::RefundReason.first.id # FIXME
           )
           # payment was processing, move back to completed
-          payment.complete!
+          payment.complete! unless payment.completed?
           notification.processed!
         end
       end

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -146,23 +146,37 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
     end
 
     context "when event is REFUND" do
-      include_examples "processed event"
-
-      let(:event_type) { :refund }
-      let(:payment_state) { "processing" }
-
-      it "creates a refund" do
-        expect { subject }.
-          to change { payment.reload.refunds.count }.
-          from(0).
-          to(1)
+      shared_examples "refund" do
+        let(:event_type) { :refund }
+        it "creates a refund" do
+          expect { subject }.
+            to change { payment.reload.refunds.count }.
+            from(0).
+            to(1)
+        end
       end
 
-      it "changes the payment state to completed" do
-        expect { subject }.
-          to change { payment.reload.state }.
-          from("processing").
-          to("completed")
+      context "when refunded from Solidus" do
+        let(:payment_state) { "processing" }
+        include_examples "refund"
+
+        it "changes the payment state to completed" do
+          expect { subject }.
+            to change { payment.reload.state }.
+            from("processing").
+            to("completed")
+        end
+      end
+
+      context "when refunded from Adyen" do
+        let(:payment_state) { "completed" }
+        include_examples "refund"
+
+        it "does not change the payment state" do
+          expect { subject }.
+            not_to change { payment.reload.state }.
+            from("completed")
+        end
       end
     end
 


### PR DESCRIPTION
Adyen sends refund notifications if you refund via their interface. This causes state machine errors because the payment is already in the completed state when this is processed, rather than in processing. This allows it to just remain completed in this case.
