### PR TITLE
Create payment in auth notification

### DIFF
--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -51,7 +51,7 @@ module Spree
     # We do this because there is a chance that we never get redirected back
     # so we need to make sure we complete the payment and order.
     def confirm_order_already_completed
-      payment = @order.payments.find_by(response_code: psp_reference)
+      payment = @order.payments.find_by!(response_code: psp_reference)
       payment.source.update(source_params)
 
       redirect_to_order

--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -12,6 +12,33 @@ module Spree
       def initialize(notification, payment = nil)
         self.notification = notification
         self.payment = payment ? payment : notification.payment
+
+        if self.payment.nil?
+          # At this point the auth was received before the redirect, we create
+          # the payment here with the information we have available so that if
+          # the user is not redirected to back for some reason we still have a
+          # record of the payment.
+          order = self.notification.order
+
+          source = Spree::Adyen::HppSource.new(
+            auth_result: "unknown",
+            order: order,
+            payment_method: notification.payment_method,
+            psp_reference: notification.psp_reference
+          )
+
+          self.payment = order.payments.create!(
+            amount: notification.money.dollars,
+            # We have no idea what payment method they used, this will be
+            # updated when/if they get redirected
+            payment_method: Spree::Gateway::AdyenHPP.last,
+            response_code: notification.psp_reference,
+            source: source,
+            order: order
+          )
+
+          order.complete
+        end
       end
 
       # for the given payment, process all notifications that are currently

--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -1,5 +1,11 @@
 module Spree
   module Adyen
+    # Class responsible for taking in a notification from Adyen and applying
+    # some form of modification to the associated payment.
+    #
+    # I would in the future like to refactor this by breaking this into
+    # separate classes that are only aware of how to process specific kinds of
+    # notifications (auth, capture, refund, etc.).
     class NotificationProcessor
       attr_accessor :notification, :payment
 

--- a/lib/spree/adyen/version.rb
+++ b/lib/spree/adyen/version.rb
@@ -1,5 +1,5 @@
 module Spree
   module Adyen
-    VERSION = "0.1.3"
+    VERSION = "0.2.0"
   end
 end

--- a/spec/controllers/spree/adyen_notifications_controller_spec.rb
+++ b/spec/controllers/spree/adyen_notifications_controller_spec.rb
@@ -5,7 +5,6 @@ describe Spree::AdyenNotificationsController do
 
   routes { Spree::Core::Engine.routes }
 
-  let(:order) { create :order }
   let(:params) do
     { "pspReference" => reference,
       "eventDate" => "2013-10-21T14:45:45.93Z",
@@ -22,12 +21,14 @@ describe Spree::AdyenNotificationsController do
       "live" => "false" }
   end
 
+  let!(:order) { create :completed_order_with_totals }
+
   let!(:payment) do
-    create :payment, response_code: reference,
-      payment_method: payment_method
+    create :hpp_payment, response_code: reference,
+      payment_method: payment_method, order: order
   end
 
-  let(:payment_method) { create :hpp_gateway }
+  let!(:payment_method) { create :hpp_gateway }
 
   let(:reference) { "8513823667306210" }
 

--- a/spec/controllers/spree/adyen_redirect_controller_spec.rb
+++ b/spec/controllers/spree/adyen_redirect_controller_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Spree::AdyenRedirectController, type: :controller do
 
     let(:psp_reference) { "8813824003752247" }
     let(:payment_method) { "amex" }
+    let(:merchantReturnData) { "#{order.guest_token}|#{gateway.id}" }
     let(:params) do
       { merchantReference: order.number,
         skinCode: "xxxxxxxx",
@@ -35,7 +36,6 @@ RSpec.describe Spree::AdyenRedirectController, type: :controller do
         merchantReturnData: merchantReturnData
       }
     end
-    let(:merchantReturnData) { [order.guest_token, gateway.id].join("|") }
 
     shared_examples "payment is successful" do
       it "changes the order state to completed" do

--- a/spec/controllers/spree/adyen_redirect_controller_spec.rb
+++ b/spec/controllers/spree/adyen_redirect_controller_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Spree::AdyenRedirectController, type: :controller do
     )
   end
 
-  let(:store) { Spree::Store.default }
-  let(:gateway) { create :hpp_gateway }
+  let!(:store) { Spree::Store.default }
+  let!(:gateway) { create :hpp_gateway }
 
   before do
     allow(controller).to receive(:check_signature)
@@ -107,6 +107,15 @@ RSpec.describe Spree::AdyenRedirectController, type: :controller do
           create(:hpp_payment, source: source, order: order)
 
           order.complete
+        end
+
+        it { expect { subject }.to_not change { order.payments.count }.from 1 }
+
+        it "updates the source" do
+          expect(order.payments.last.source).to have_attributes(
+            auth_result: "AUTHORISED",
+            skin_code: "XXXXXXXX"
+          )
         end
 
         include_examples "payment is successful"

--- a/spec/factories/spree_payment.rb
+++ b/spec/factories/spree_payment.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
 
     before :create do |record, _|
       # these associations/keys are awful and are making this difficult
+      record.response_code = record.source.psp_reference
       record.source.order = record.order
       record.source.merchant_reference = record.order.number
     end

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
 
     let!(:order) do
       # spree factories suck, it's not easy to get something to payment state
-      create(:order_with_line_items, currency: "EUR").tap do |order|
+      create(:order_with_line_items).tap do |order|
         order.contents.advance
         expect(order.state).to eq "payment"
       end
@@ -34,7 +34,7 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
         event_type, # these are registered traits, refer to the factory
         success: success,
         value: 2399,
-        currency: "EUR",
+        currency: "USD",
         payment: payment,
         order: order
       )

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -102,8 +102,6 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
     context "when event is AUTHORISATION" do
       let(:event_type) { :auth }
 
-      it "changes the available actions"
-
       context "and payment method was c_cash", pending: true do
         pending "completes payment"
       end

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -12,9 +12,11 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
         amount: 23.99,
         state: payment_state,
         payment_method: hpp_gateway,
-        order: create(:order, currency: "EUR")
+        order: order
       )
     end
+
+    let!(:order) { create(:order, currency: "EUR") }
 
     let!(:hpp_gateway) do
       create(:hpp_gateway)
@@ -27,7 +29,8 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
         success: success,
         value: 2399,
         currency: "EUR",
-        payment: payment
+        payment: payment,
+        order: order
       )
     end
 

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
       end
 
       it "completes the payment" do
-        expect{ subject }.
+        expect { subject }.
           to change{ payment.reload.state }.
           from("pending").
           to("completed")


### PR DESCRIPTION
This will create the payment in the auth notification if it doesn't already exist.

This serves as a safeguard against users never being redirected to the
completion page, causing the payment to never be created, which happens in live
a not insignificant amount.
