### PR TITLE
Don't attempt to make payments when notifications don't relate to order

### DIFF
--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -115,6 +115,8 @@ module Spree
       def create_missing_payment
         order = notification.order
 
+        return unless order
+
         source = Spree::Adyen::HppSource.new(
           auth_result: "unknown",
           order: order,

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -248,4 +248,24 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
         and change { payment.captured_amount }.from(0).to(19.99)
     end
   end
+
+  describe "#new" do
+    subject { described_class.new(notification) }
+    context "notification not related to order" do
+      let!(:notification) do
+        create(
+          :notification,
+          :auth,
+          success: true,
+          value: 2399,
+          currency: "USD",
+          merchant_reference: "not an order number"
+        )
+      end
+
+      it "does not create a payment" do
+        expect { subject }.not_to change { Spree::Payment.count }
+      end
+    end
+  end
 end


### PR DESCRIPTION
There are many notification types which don't relate to orders, so we don't want to try processing or creating payments for these.

Easiest test case is running Adyen's test notifications against the notify endpoint.
