### PR TITLE
Look up order with order number

### DIFF
--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -78,9 +78,7 @@ module Spree
 
       @payment_method = Spree::PaymentMethod.find(payment_method_id)
 
-      @order =
-        Spree::Order.
-        find_by!(guest_token: cookies.signed[:guest_token])
+      @order = Spree::Order.find_by!(number: order_number)
     end
 
     def source_params
@@ -93,6 +91,10 @@ module Spree
         :paymentMethod,
         :shopperLocale,
         :merchantReturnData)
+    end
+
+    def order_number
+      params[:merchantReference]
     end
 
     def psp_reference


### PR DESCRIPTION
Fixes #41 

Creating multiple orders in the same browser causes a 404 on the completion page if the order is already completed by an authorization notification. This happens because the order lookup is done by the guest token, and new order will have the same guest token if the cookie for it is already set.

Because of this the first order is found and then the system attempts to look up the payment by an identifier and because this is the wrong order it doesn't have this payment, causing a 404.
