### PR TITLE
Don't render layout for hpp directory

### DIFF
--- a/app/controllers/spree/adyen/hpps_controller.rb
+++ b/app/controllers/spree/adyen/hpps_controller.rb
@@ -7,6 +7,8 @@ module Spree
         class: "Spree::PaymentMethod",
         id_param: :payment_method_id)
 
+      layout false
+
       def directory
         @brands = Adyen::Form.payment_methods_from_directory(
           @order,


### PR DESCRIPTION
This gets shimmed into the page, so essentially there is a layout in the
middle of the layout.
