### PR TITLE
Prevent race condition between notification and redirect

### DIFF
--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -13,7 +13,10 @@ module Spree
 
       notification.save!
 
-      Spree::Adyen::NotificationProcessor.new(notification).process!
+      # prevent alteration to associated payment while we're handling the action
+      ActiveRecord::Base.transaction do
+        Spree::Adyen::NotificationProcessor.new(notification).process!
+      end
       accept
     end
 

--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -21,34 +21,30 @@ module Spree
       # for the given payment, process all notifications that are currently
       # unprocessed in the order that they were dispatched.
       def self.process_outstanding!(payment)
-        Spree::Payment.transaction do
-          payment.
-            source.
-            notifications(true). # bypass caching
-            unprocessed.
-            as_dispatched.
-            map do |notification|
-              new(notification, payment).process!
-            end
-        end
+        payment.
+          source.
+          notifications(true). # bypass caching
+          unprocessed.
+          as_dispatched.
+          map do |notification|
+            new(notification, payment).process!
+          end
       end
 
       # only process the notification if there is a matching payment there's a
       # number of reasons why there may not be a matching payment such as test
       # notifications, reports etc, we just log them and then accept
       def process!
-        Spree::Payment.transaction do
-          if payment
-            if !notification.success?
-              handle_failure
+        if payment
+          if !notification.success?
+            handle_failure
 
-            elsif notification.modification_event?
-              handle_modification_event
+          elsif notification.modification_event?
+            handle_modification_event
 
-            elsif notification.normal_event?
-              handle_normal_event
+          elsif notification.normal_event?
+            handle_normal_event
 
-            end
           end
         end
 


### PR DESCRIPTION
fixes #39 

Prior to this on the payment `process!` method occurred in a
transaction. Due to the fact that the payment was been created in the
initialization the entire action was not atomic.

Moving the transaction up to the controller where `.new(...).process!` is
should make the entire action atomic and prevent a new payment from
being created if the notification and redirect occur simultaneously.
