### PR TITLE
Don't create payment unless it's a successful auth

### DIFF
--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -13,7 +13,7 @@ module Spree
         self.notification = notification
         self.payment = payment ? payment : notification.payment
 
-        if self.payment.nil? && self.notification.order.present?
+        if should_create_payment?
           self.payment = create_missing_payment
         end
       end
@@ -131,6 +131,14 @@ module Spree
         order.complete
         payment
       end
+
+      def should_create_payment?
+        notification.authorisation? &&
+        notification.success? &&
+        notification.order.present? &&
+        payment.nil?
+      end
+
     end
   end
 end

--- a/spec/controllers/spree/adyen_notifications_controller_spec.rb
+++ b/spec/controllers/spree/adyen_notifications_controller_spec.rb
@@ -24,8 +24,17 @@ describe Spree::AdyenNotificationsController do
   let!(:order) { create :completed_order_with_totals }
 
   let!(:payment) do
-    create :hpp_payment, response_code: reference,
-      payment_method: payment_method, order: order
+    create(
+      :hpp_payment,
+      response_code: reference,
+      payment_method: payment_method,
+      order: order,
+      source: create(
+        :hpp_source,
+        psp_reference: reference,
+        order: order
+      )
+    )
   end
 
   let!(:payment_method) { create :hpp_gateway }


### PR DESCRIPTION
fixes #40

payments were being created during processing if they didn't exist, even
when receiving notifications that weren't successful authorizations.
