### PR TITLE
Use transaction with lock on order

### DIFF
--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -14,9 +14,7 @@ module Spree
       notification.save!
 
       # prevent alteration to associated payment while we're handling the action
-      ActiveRecord::Base.transaction do
-        Spree::Adyen::NotificationProcessor.new(notification).process!
-      end
+      Spree::Adyen::NotificationProcessor.new(notification).process!
       accept
     end
 

--- a/solidus-adyen.gemspec
+++ b/solidus-adyen.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sass-rails", "~> 4.0.2"
   spec.add_development_dependency "coffee-rails"
 
+  spec.add_development_dependency "pg"
   spec.add_development_dependency "sqlite3"
 
   spec.add_development_dependency "rspec-rails", "~> 3.3"

--- a/spec/controllers/spree/adyen_redirect_controller_spec.rb
+++ b/spec/controllers/spree/adyen_redirect_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Spree::AdyenRedirectController, type: :controller do
     )
   end
 
-  let!(:store) { Spree::Store.default }
+  let!(:store) { create :store }
   let!(:gateway) { create :hpp_gateway }
 
   before do

--- a/spec/factories/spree_gateway_adyen_hpp.rb
+++ b/spec/factories/spree_gateway_adyen_hpp.rb
@@ -16,7 +16,7 @@ FactoryGirl.define do
       preferred_api_password { ENV.fetch("ADYEN_API_PASSWORD") }
       preferred_api_username { ENV.fetch("ADYEN_API_USERNAME") }
       preferred_merchant_account { ENV.fetch("ADYEN_MERCHANT_ACCOUNT") }
-      preferred_shared_secret { ENV.fetch("ADYEN_SKIN_CODE") }
+      preferred_shared_secret { ENV.fetch("ADYEN_SHARED_SECRET") }
       preferred_skin_code { ENV.fetch("ADYEN_SKIN_CODE") }
     end
   end

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -130,6 +130,43 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
           include_examples "does nothing"
         end
       end
+
+      # this is for the situation where we can the notification before the
+      # redirect
+      context "and the payment doesn't exist yet" do
+        let(:payment) { nil }
+
+        context "an it is not a successful auth notification" do
+          let(:notification) do
+            create(:notification, :auth, success: false, order: order)
+          end
+
+          it "does not create a payment" do
+            expect { subject }.to_not change { order.payments.count }
+          end
+
+          it "does not complete the order" do
+            expect { subject }.to_not change { order.state }
+          end
+        end
+
+        context "and it is a successful auth notification" do
+          let(:notification) do
+            create(:notification, :auth, order: order)
+          end
+
+          it "creates a payment" do
+            expect { subject }.
+              to change { order.payments.count }.
+              to 1
+          end
+
+          it "completes the order" do
+            expect { subject }.
+              to change { order.state }.to "complete"
+          end
+        end
+      end
     end
 
     context "when event is CAPTURE" do
@@ -223,61 +260,6 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
         to change { payment.state }.from("pending").to("completed").
 
         and change { payment.captured_amount }.from(0).to(19.99)
-    end
-  end
-
-  describe "#new" do
-    subject { described_class.new(notification) }
-    context "notification not related to order" do
-      let!(:notification) do
-        create(
-          :notification,
-          :auth,
-          success: true,
-          value: 2399,
-          currency: "USD",
-          merchant_reference: "not an order number"
-        )
-      end
-
-      it "does not create a payment" do
-        expect { subject }.not_to change { Spree::Payment.count }
-      end
-    end
-
-    # this is for the situation where we can the notification before the
-    # redirect
-    context "and the payment doesn't exist yet" do
-      context "an it is not a successful auth notification" do
-        let(:notification) do
-          create(:notification, :auth, success: false, order: order)
-        end
-
-        it "does not create a payment" do
-          expect { subject }.to_not change { order.payments.count }
-        end
-
-        it "does not complete the order" do
-          expect { subject }.to_not change { order.state }
-        end
-      end
-
-      context "and it is a successful auth notification" do
-        let(:notification) do
-          create(:notification, :auth, order: order)
-        end
-
-        it "creates a payment" do
-          expect { subject }.
-            to change { order.payments.count }.
-            to 1
-        end
-
-        it "completes the order" do
-          expect { subject }.
-            to change { order.state }.to "complete"
-        end
-      end
     end
   end
 end

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -153,6 +153,8 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
     end
 
     context "when event is REFUND" do
+      before { create :refund_reason }
+
       shared_examples "refund" do
         let(:event_type) { :refund }
         it "creates a refund" do


### PR DESCRIPTION
Lock the order by row to prevent completing segments from creating a new
payment + payment source and attempting to complete the order.

Both sections do more or less the same thing so they really need to happen
in isolation as they branch based on whether or not the order is completed.
