### PR TITLE
add support for one-page payment flow

### DIFF
--- a/lib/spree/adyen/form.rb
+++ b/lib/spree/adyen/form.rb
@@ -11,6 +11,10 @@ module Spree
           payment_methods(order, payment_method)
         end
 
+        def pay_url order, payment_method
+          endpoint_url "pay", order, payment_method
+        end
+
         def select_url order, payment_method
           endpoint_url "select", order, payment_method
         end

--- a/spec/lib/spree/adyen/form_spec.rb
+++ b/spec/lib/spree/adyen/form_spec.rb
@@ -183,6 +183,18 @@ RSpec.describe Spree::Adyen::Form do
     end
   end
 
+  describe "pay_url" do
+    subject {
+      described_class.pay_url(order, payment_method)
+    }
+
+    it "calls endpoint url with the expected params" do
+      expect(described_class).to receive(:endpoint_url).
+                                     with("pay", order, payment_method)
+      subject
+    end
+  end
+
   describe "details_url_with_issuer" do
     let(:issuer_id) { "1654" }
     let(:brand_code) { "paypal" }

--- a/spec/lib/spree/adyen/form_spec.rb
+++ b/spec/lib/spree/adyen/form_spec.rb
@@ -189,8 +189,9 @@ RSpec.describe Spree::Adyen::Form do
     }
 
     it "calls endpoint url with the expected params" do
-      expect(described_class).to receive(:endpoint_url).
-                                     with("pay", order, payment_method)
+      expect(described_class).
+          to receive(:endpoint_url).
+          with("pay", order, payment_method)
       subject
     end
   end


### PR DESCRIPTION
This PR adds a methods that generates a URL for Adyen's one-page payment flow [0]. We needed this since we don't do a directory lookup, but redirect immediately to Adyen's payment page. Would be great if this could be merged.

[0] https://docs.adyen.com/display/TD/One-page
