### PR TITLE
Include shopper_locale in params

### DIFF
--- a/lib/spree/adyen/form.rb
+++ b/lib/spree/adyen/form.rb
@@ -118,7 +118,8 @@ module Spree
           { currency_code: order.currency,
             merchant_reference: order.number.to_s,
             country_code: order.billing_address.country.iso,
-            payment_amount: (order.total * 100).to_int
+            payment_amount: (order.total * 100).to_int,
+            shopper_locale: I18n.locale
           }
         end
 

--- a/spec/lib/spree/adyen/form_spec.rb
+++ b/spec/lib/spree/adyen/form_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Spree::Adyen::Form do
      shared_secret: "1234567890",
      days_to_ship: 3}
   }
+  let(:locale) { I18n.locale }
 
   describe "directory_url" do
     let(:expected) do
@@ -27,7 +28,8 @@ RSpec.describe Spree::Adyen::Form do
         shared_secret: payment_method.shared_secret,
         country_code: order.billing_address.country.iso,
         merchant_return_data: merchant_return_data,
-        payment_amount: 3998
+        payment_amount: 3998,
+        shopper_locale: locale
       }
 
        ::Adyen::Form.redirect_url(redirect_params)


### PR DESCRIPTION
This uses I18n.locale to set the default shopper_locale. Adyen will now use the locale to determine the language of the payment form.
