### PR TITLE
Shopper locale should have an underscore as the separator.

### DIFF
--- a/lib/spree/adyen/form.rb
+++ b/lib/spree/adyen/form.rb
@@ -123,7 +123,7 @@ module Spree
             merchant_reference: order.number.to_s,
             country_code: order.billing_address.country.iso,
             payment_amount: (order.total * 100).to_int,
-            shopper_locale: I18n.locale
+            shopper_locale: I18n.locale.to_s.gsub("-", "_")
           }
         end
 

--- a/spec/lib/spree/adyen/form_spec.rb
+++ b/spec/lib/spree/adyen/form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Spree::Adyen::Form do
      shared_secret: "1234567890",
      days_to_ship: 3}
   }
-  let(:locale) { I18n.locale }
+  let(:locale) { I18n.locale.to_s.gsub("-", "_") }
 
   describe "directory_url" do
     let(:expected) do


### PR DESCRIPTION
As described https://docs.adyen.com/display/TD/HPP+payment+fields the shopper locale should have an underscore as a separator rather than a dash which rails does by default.

Currently breaks Trustly, but not the others LMN uses, but there might be more affected.
