### PR TITLE
Add back uniqness constraint

### DIFF
--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -6,15 +6,13 @@ module Spree
 
     def notify
       notification = AdyenNotification.build(params)
-
-      if notification.duplicate?
-        accept and return
-      end
-
       notification.save!
 
       # prevent alteration to associated payment while we're handling the action
       Spree::Adyen::NotificationProcessor.new(notification).process!
+      accept
+    rescue ActiveRecord::RecordNotUnique
+      # Notification is a duplicate, ignore it and return a success.
       accept
     end
 

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -53,7 +53,6 @@ class AdyenNotification < ActiveRecord::Base
 
   validates_presence_of :event_code
   validates_presence_of :psp_reference
-  validates_uniqueness_of :success, scope: [:psp_reference, :event_code]
 
   # Logs an incoming notification into the database.
   #

--- a/db/migrate/20151123000000_recreate_adyen_notification_index.rb
+++ b/db/migrate/20151123000000_recreate_adyen_notification_index.rb
@@ -1,0 +1,5 @@
+class RecreateAdyenNotificationIndex < ActiveRecord::Migration
+  def change
+    add_index :adyen_notifications, [:psp_reference, :event_code, :success], unique: true, name: "adyen_notification_uniqueness"
+  end
+end


### PR DESCRIPTION
I can't really remember why we removed this in the first place but we're
adding them back.

Relying on rails validationfor a uniqueness constraint is suspect for
causing race conditions when receiving multiple notifications in quick
succession.
