### PR TITLE
Add Trustly and Giropay as bank transfer methods

### DIFF
--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -16,7 +16,12 @@
 #      @invoice.set_paid!
 #    end
 class AdyenNotification < ActiveRecord::Base
-  AUTO_CAPTURE_ONLY_METHODS = ["ideal", "c_cash", "directEbanking"].freeze
+  AUTO_CAPTURE_ONLY_METHODS = [
+    "ideal",
+    "c_cash",
+    "directEbanking",
+    "trustly"
+  ].freeze
 
   AUTHORISATION = "AUTHORISATION".freeze
   CANCELLATION = "CANCELLATION".freeze

--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -20,7 +20,8 @@ class AdyenNotification < ActiveRecord::Base
     "ideal",
     "c_cash",
     "directEbanking",
-    "trustly"
+    "trustly",
+    "giropay"
   ].freeze
 
   AUTHORISATION = "AUTHORISATION".freeze


### PR DESCRIPTION
Trustly and Giropay work a lot like iDEAL and Sofort, and should be considered as bank transfer methods.
