### PR TITLE
Add bcmc as auto capture only

### DIFF
--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -21,7 +21,8 @@ class AdyenNotification < ActiveRecord::Base
     "c_cash",
     "directEbanking",
     "trustly",
-    "giropay"
+    "giropay",
+    "bcmc"
   ].freeze
 
   AUTHORISATION = "AUTHORISATION".freeze


### PR DESCRIPTION
Noticed captures were failing from Solidus because bcmc payments had become auto-capture, even though our settings were otherwise. Talking with Adyen support they've changed their bcmc integration to only be auto-capture, so that's how we're going to have to roll!
