### PR TITLE
Notification can find payments when there is no reference

### DIFF
--- a/spec/models/adyen_notification_spec.rb
+++ b/spec/models/adyen_notification_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe AdyenNotification do
       let(:attr) { :psp_reference }
       include_examples "finds the payment"
     end
+
+    context "payment with no reference" do
+      let!(:payment) { create :payment, response_code: nil }
+
+      context "normal notification" do
+        let!(:notification) {
+          described_class.new :merchant_reference => payment.order.number
+        }
+        include_examples "finds the payment"
+      end
+    end
   end
 
   describe "#build" do


### PR DESCRIPTION
For Trustly, for whatever reason, Adyen doesn't provide a psp reference in the redirect, so the original payment created in the redirect has a nil response_code. This means when the notification comes in it doesn't link with the payment and creates _another_ payment, so each Trustly order has a 'pending' payment and a 'complete' payment.

This PR adds in functionality so that if a payment isn't found for a notification it looks for the last Adyen payment without a response code, and uses that instead.

I'd like something better than what I've got for the where clause in that query, but I've been away from this for a month and a bit so I'm a bit slow to think of something better.
