### PR TITLE
Fix for refund amount losing cents

### DIFF
--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -77,7 +77,7 @@ module Spree
 
         elsif notification.refund?
           payment.refunds.create!(
-            amount: notification.value / 100, # cents to dollars
+            amount: notification.value / 100.0, # cents to dollars
             transaction_id: notification.psp_reference,
             refund_reason_id: ::Spree::RefundReason.first.id # FIXME
           )

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -200,6 +200,11 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
             from(0).
             to(1)
         end
+
+        it "creates a refund of the correct value" do
+          subject
+          expect(payment.reload.refunds.last.amount).to eq 23.99
+        end
       end
 
       context "when refunded from Solidus" do


### PR DESCRIPTION
Amount of the refund was calculated with integer division, so we lost the cents value, leading to small inconsistencies in refunded orders if made from Adyen. This fixes it by dividing by a float.
