### PR TITLE
Don't attempt to find a payment if we don't have an order.

### DIFF
--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -89,10 +89,12 @@ class AdyenNotification < ActiveRecord::Base
 
     # If no reference take the last payment in the associated order where the
     # response_code was nil.
-    order
-      .payments
-      .where(source_type: "Spree::Adyen::HppSource", response_code: nil)
-      .last
+    if order
+      order
+        .payments
+        .where(source_type: "Spree::Adyen::HppSource", response_code: nil)
+        .last
+    end
   end
 
   # Returns true if this notification is an AUTHORISATION notification

--- a/spec/models/adyen_notification_spec.rb
+++ b/spec/models/adyen_notification_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe AdyenNotification do
         include_examples "finds the payment"
       end
     end
+
+    context "no connected order" do
+      let!(:notification) {
+        described_class.new :merchant_reference => "notarealorder"
+      }
+      it { is_expected.to eq nil }
+    end
   end
 
   describe "#build" do


### PR DESCRIPTION
Fixes an issue for the test notifications which Adyen sends, because those obviously don't have an associated payment.
