### PR TITLE
Add the psp reference as the response code if it doesn't exist.

### DIFF
--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -89,6 +89,13 @@ module Spree
 
       # normal event is defined as just AUTHORISATION
       def handle_normal_event
+        # Payment may not have psp_reference. Add this from notification if it
+        # doesn't have one.
+        unless self.payment.response_code
+          payment.response_code = notification.psp_reference
+          payment.save
+        end
+
         if notification.auto_captured?
           complete_payment!
 


### PR DESCRIPTION
In a previous PR (#64) we fixed an issue where the redirect didn't have a `psp_reference`, so couldn't combine with the notification properly. However the PR only fixed the scenario where the redirect was first. This ties up the loose ends when the notification is first, and adds a test for the issue when `psp_reference` isn't included in the redirect response.
