### PR TITLE
Update the test cards link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ with the proper end point to receive notifications.
 
 # Test Credit Card Info
 
-https://support.adyen.com/index.php?/Knowledgebase/Article/View/11/0/test-card-numbers
+https://www.adyen.com/home/support/knowledgebase/implementation-articles?article=kb_imp_17
 
 # Terminology and other API information
 [More info about Adyen can be found here](https://docs.adyen.com/display/TD/3D+Secure).


### PR DESCRIPTION
The old link led to a redirect to the link I've now added. However the site which did the redirect is now 'undergoing maintenance' which has lasted at least 4 days, so let's just use the direct link instead.
