### PR TITLE
Move development dependencies to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,3 @@
 source "https://rubygems.org"
 
-gem "solidus"
-gem "solidus_auth_devise", "~> 1.2.0"
-
-group :test do
-  gem "database_cleaner"
-  gem "factory_girl"
-  gem "pg"
-  gem "timecop"
-  gem "vcr"
-  gem "webmock"
-end
-
 gemspec

--- a/solidus-adyen.gemspec
+++ b/solidus-adyen.gemspec
@@ -22,10 +22,19 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "solidus_core", "~> 1.1"
   spec.add_runtime_dependency "bourbon"
 
+  spec.add_development_dependency "solidus"
+  spec.add_development_dependency "solidus_auth_devise", "~>1.2.0"
+
   spec.add_development_dependency "sass-rails", "~> 4.0.2"
   spec.add_development_dependency "coffee-rails"
 
+  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "mysql2"
   spec.add_development_dependency "pg"
+
+  spec.add_development_dependency "timecop"
+  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "vcr"
 
   spec.add_development_dependency "rspec-rails", "~> 3.3"
   spec.add_development_dependency "rspec-activemodel-mocks"


### PR DESCRIPTION
This commit unifies the locations for development and test dependencies
to the `.gemspec` as per the recommendation in [1].

It also adds `mysql2` and `sqlite3` as dependencies so that the test_app
kann be built without Postgres.

[1](http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/)
