### PR TITLE
Allow using MySQL and SQLite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,17 @@
 source "https://rubygems.org"
 
-gem "solidus"
-gem "solidus_auth_devise", "~> 1.2.0"
+group :development, :test do
+  gem "solidus"
+  gem "solidus_auth_devise", "~> 1.2.0"
+
+  gem "pg"
+  gem "mysql2"
+  gem "sqlite3"
+end
 
 group :test do
   gem "database_cleaner"
   gem "factory_girl"
-  gem "pg"
   gem "timecop"
   gem "vcr"
   gem "webmock"

--- a/solidus-adyen.gemspec
+++ b/solidus-adyen.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rspec-rails", "~> 3.3"
   spec.add_development_dependency "rspec-activemodel-mocks"
-  spec.add_development_dependency "factory_girl"
   spec.add_development_dependency "shoulda-matchers"
 
   spec.add_development_dependency "simplecov"
@@ -45,5 +44,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "capybara"
   spec.add_development_dependency "poltergeist"
   spec.add_development_dependency "launchy"
-  spec.add_development_dependency "database_cleaner"
 end


### PR DESCRIPTION
Right now, the gem can not be used with SQlite or MySQL as a dev database.
This commit changes it such that SQLite and MySQL can be used as well.
Furthermore it moves the `Gemfile`s gem dependencies to the correct groups.
