### PR TITLE
Cap webmock to pre 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem "factory_girl"
   gem "timecop"
   gem "vcr"
-  gem "webmock"
+  gem "webmock", "~> 1.24"
 end
 
 gemspec


### PR DESCRIPTION
There's an issue with webmock 2.0 that makes it incompatible with VCR
