### PR TITLE
Fix intermittent test failure

### DIFF
--- a/spec/lib/tasks/requests/notification_processing_spec.rb
+++ b/spec/lib/tasks/requests/notification_processing_spec.rb
@@ -149,8 +149,8 @@ RSpec.describe "Notification processing", type: :request do
         end
 
         redirect_request = lambda do
-          get "/checkout/payment/adyen", checkout_params, headers
-          expect(response).to have_http_status :redirect
+          response_code = get "/checkout/payment/adyen", checkout_params, headers
+          expect(response_code).to eq 302
         end
 
         capture_request = lambda do


### PR DESCRIPTION
When running the entire suite, under some  scenarios the value of
`response` is nil.

Simply assigning the response from `get` solves this as the value
contains the response code - which was the only thing under test.
