### PR TITLE
Remove dev dependency locks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :development, :test do
   gem "solidus"
-  gem "solidus_auth_devise", "~> 1.2.0"
+  gem "solidus_auth_devise"
 
   gem "pg"
   gem "mysql2"

--- a/solidus-adyen.gemspec
+++ b/solidus-adyen.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "solidus_core", "~> 1.1"
   spec.add_runtime_dependency "bourbon"
 
-  spec.add_development_dependency "sass-rails", "~> 4.0.2"
+  spec.add_development_dependency "sass-rails"
   spec.add_development_dependency "coffee-rails"
 
   spec.add_development_dependency "pg"

--- a/spec/models/spree/adyen/hpp_source_spec.rb
+++ b/spec/models/spree/adyen/hpp_source_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Spree::Adyen::HppSource do
     create :hpp_source,
       psp_reference: "999999999",
       merchant_reference: "R11111111",
-      payment: create(:hpp_payment)
+      payment: create(:hpp_payment, amount: 1)
   end
 
   describe ".actions" do


### PR DESCRIPTION
Locking sass-rails to 4.0.2 was totally unnessary and prevent solidus
1.2 from being used in dev
