### PR TITLE
Update confirm action redirect

### DIFF
--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -75,6 +75,7 @@ module Spree
 
     def redirect_to_order
       flash.notice = Spree.t(:order_processed_successfully)
+      flash['order_completed'] = true
       redirect_to order_path(@order)
     end
 

--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -74,6 +74,7 @@ module Spree
     end
 
     def redirect_to_order
+      @current_order = nil
       flash.notice = Spree.t(:order_processed_successfully)
       flash['order_completed'] = true
       redirect_to order_path(@order)


### PR DESCRIPTION
[Solidus Frontend](https://github.com/solidusio/solidus/blob/master/frontend/app/controllers/spree/checkout_controller.rb#L40) unsets `@current_order` and sets a `order_completed` flash message, so the confirm redirect probably should do this too.

Setting the latter enables the `order_just_completed?` helper to work correctly.
