### PR TITLE
Spree::OrderMutex to Lock order to prevent race conditions

### DIFF
--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -14,6 +14,8 @@ module Spree
     rescue ActiveRecord::RecordNotUnique
       # Notification is a duplicate, ignore it and return a success.
       accept
+    rescue Spree::OrderMutex::LockFailed, ArguementError
+      refuse
     end
 
     protected
@@ -28,6 +30,10 @@ module Spree
     private
     def accept
       render text: "[accepted]"
+    end
+
+    def refuse
+      render text: "[refused]"
     end
   end
 end

--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -14,7 +14,7 @@ module Spree
       end
 
       accept
-    rescue ActiveRecord::RecordNotUnique, ArguementError
+    rescue ActiveRecord::RecordNotUnique, ::ArguementError
       # Notification is a duplicate, ignore it and return a success.
       accept
     rescue Spree::OrderMutex::LockFailed

--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -14,7 +14,7 @@ module Spree
       end
 
       accept
-    rescue ActiveRecord::RecordNotUnique, ::ArguementError
+    rescue ActiveRecord::RecordNotUnique, ArgumentError
       # Notification is a duplicate, ignore it and return a success.
       accept
     rescue Spree::OrderMutex::LockFailed

--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -12,7 +12,7 @@ module Spree
       # This and the notification processing need to have a lock on the order
       # as they both decide what to do based on whether or not the order is
       # complete.
-      @order.with_lock do
+      Spree::OrderMutex.with_lock!(@order) do
         if @order.complete?
           confirm_order_already_completed
         else

--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -19,6 +19,9 @@ module Spree
           confirm_order_incomplete
         end
       end
+
+    rescue Spree::OrderMutex::LockFailed
+      render :confirm
     end
 
     private

--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -34,21 +34,19 @@ module Spree
       def process!
         return notification if order.nil?
 
-        Spree::OrderMutex.with_lock!(order) do
-          if should_create_payment?
-            self.payment = create_missing_payment
-          end
+        if should_create_payment?
+          self.payment = create_missing_payment
+        end
 
-          if !notification.success?
-            handle_failure
+        if !notification.success?
+          handle_failure
 
-          elsif notification.modification_event?
-            handle_modification_event
+        elsif notification.modification_event?
+          handle_modification_event
 
-          elsif notification.normal_event?
-            handle_normal_event
+        elsif notification.normal_event?
+          handle_normal_event
 
-          end
         end
 
         return notification

--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -34,7 +34,7 @@ module Spree
       def process!
         return notification if order.nil?
 
-        order.with_lock do
+        Spree::OrderMutex.with_lock!(order) do
           if should_create_payment?
             self.payment = create_missing_payment
           end

--- a/app/views/spree/adyen_redirect/confirm.html.erb
+++ b/app/views/spree/adyen_redirect/confirm.html.erb
@@ -1,0 +1,9 @@
+<script type="text/javascript">
+  setTimeout(function(){
+    window.location.reload()
+  }, 10 * 1000);
+</script>
+
+<h1><%= t('solidus-adyen.redirection.you_are_being_redirected') %></h1>
+
+<p><%= t('solidus-adyen.redirection.please_click_here', link: request.original_url) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,9 @@ en:
           Reason: "Reason"
           amount: "Amount"
   solidus-adyen:
+    redirection:
+      you_are_being_redirected: 'You are being redirected'
+      please_click_here: 'Please <a href="%{link}">click here</a> if your browser does not redirect you.'
     payment:
       failure: "Action failed, check reason for more information."
       success: "Action succeeded."


### PR DESCRIPTION
When using the gateway with iDEAL for a client we've had a race condition, which incorrectly left the payment in pending.

A notification was created as expect, but when the notification was retried by Adyen it was (the notification.save!) was throwing an `ActiveRecord::RecordNotUnique` error.

The Rails `with_lock` should stop this from happening but it doesn't, and was also failing silently.

When the with_lock was replaced by the OrderMutex, errors where correctly thrown. This meant Adyen notifications could be refused for a retry.

The return from Adyen also rescues the LockFailed and renders a page that will reload current url to successfully complete the order.
