### PR TITLE
PSP Reference column limit causing error when reports have long filenames 

### DIFF
--- a/db/migrate/20161107113101_alter_psp_reference_column.rb
+++ b/db/migrate/20161107113101_alter_psp_reference_column.rb
@@ -1,0 +1,9 @@
+class AlterPspReferenceColumn < ActiveRecord::Migration
+  def up
+    change_column :adyen_notifications, :psp_reference, :string, limit: 255
+  end
+
+  def down
+    change_column :adyen_notifications, :psp_reference, :string, limit: 50
+  end
+end

--- a/spec/controllers/spree/adyen_notifications_controller_spec.rb
+++ b/spec/controllers/spree/adyen_notifications_controller_spec.rb
@@ -101,6 +101,26 @@ describe Spree::AdyenNotificationsController do
           to change { AdyenNotification.count }.by(1)
         end
       end
+
+      context "notification contains a long report filename" do
+        let(:params) do
+          { "reason" => "https://ca-test.adyen.com/reports/download/MerchantAccount/"\
+            "A_Client_with_a_long_merchant_account/invoice-201605000203.MerchantAccount."\
+            "A_Client_with_a_long_merchant_account-UK_WO.pdf",
+            "merchantAccountCode" => "A_Client_with_a_long_merchant_account",
+            "eventCode" => "REPORT_AVAILABLE",
+            "success" => "true",
+            "currency" => "GBP",
+            "pspReference" => "invoice-201605000203.MerchantAccount.A_Client_with_a_long_merchant_account-UK_WO.pdf",
+            "value" => "0",
+            "live" => "false",
+            "eventDate" => "2016-06-08T17:48:54.79Z" }
+        end
+
+        before { bypass_auth }
+
+        include_examples "logs the notification"
+      end
     end
 
     context "request not authenticated" do


### PR DESCRIPTION
The filenames of the invoices sent back from Adyen exceed the PSP reference column limit.

This caused an `ActiveRecord:StatementInvalid`, which as a side effect this prevented the PayPal payments from completing.
