### PR TITLE
Ignore duplicate notifications from Adyen

### DIFF
--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -5,15 +5,16 @@ module Spree
     before_filter :authenticate
 
     def notify
-      notification = AdyenNotification.build(params)
-      notification.save!
+      if notification_exists?(params)
+        accept
+      else
+        notification = AdyenNotification.build(params)
+        notification.save!
 
-      # prevent alteration to associated payment while we're handling the action
-      Spree::Adyen::NotificationProcessor.new(notification).process!
-      accept
-    rescue ActiveRecord::RecordNotUnique
-      # Notification is a duplicate, ignore it and return a success.
-      accept
+        # prevent alteration to associated payment while we're handling the action
+        Spree::Adyen::NotificationProcessor.new(notification).process!
+        accept
+      end
     end
 
     protected
@@ -28,6 +29,13 @@ module Spree
     private
     def accept
       render text: "[accepted]"
+    end
+
+    def notification_exists? params
+      AdyenNotification.where(
+        psp_reference: params["pspReference"],
+        event_code: params["eventCode"]
+      ).any?
     end
   end
 end

--- a/app/models/spree/gateway/adyen_credit_card.rb
+++ b/app/models/spree/gateway/adyen_credit_card.rb
@@ -80,7 +80,7 @@ module Spree
 
     def authorize_payment(amount, card, gateway_options, instant_capture = false)
       provider.authorise_recurring_payment(
-        gateway_options[:order_id],
+        gateway_options[:order_id].split("-").first,
         amount_from_gateway_options(amount, gateway_options),
         shopper_data_from_gateway_options(gateway_options),
         card.gateway_customer_profile_id,

--- a/spec/models/spree/gateway/adyen_credit_card_spec.rb
+++ b/spec/models/spree/gateway/adyen_credit_card_spec.rb
@@ -236,7 +236,7 @@ describe Spree::Gateway::AdyenCreditCard do
 
       it "calls the Adyen service with the right options and returns the correct object" do
         expect(gateway.provider).to receive(:authorise_recurring_payment).with(
-          "R423936067-5D5ZHURX",
+          "R423936067",
           { value: 2000, currency: "USD" },
           { reference: 1, email: "spree@example.com", ip: "1.2.3.4", statement: "R423936067-5D5ZHURX" },
           "CARDIDATADYEN",
@@ -303,7 +303,7 @@ describe Spree::Gateway::AdyenCreditCard do
 
       it "calls the Adyen service with the right options and returns the correct object" do
         expect(gateway.provider).to receive(:authorise_recurring_payment).with(
-          "R423936067-5D5ZHURX",
+          "R423936067",
           { value: 2000, currency: "USD" },
           { reference: 1, email: "spree@example.com", ip: "1.2.3.4", statement: "R423936067-5D5ZHURX" },
           "CARDIDATADYEN",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ require "ffaker"
 require "shoulda/matchers"
 require "pry"
 require "database_cleaner"
+require "capybara/poltergeist"
 
 require "spree/testing_support/factories"
 require "spree/testing_support/controller_requests"
@@ -37,7 +38,7 @@ Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each {|f| require f }
 FactoryGirl.definition_file_paths = %w{./spec/factories}
 FactoryGirl.find_definitions
 
-Capybara.javascript_driver = :selenium
+Capybara.javascript_driver = :poltergeist
 
 RSpec.configure do |config|
   RSpec::Matchers.define_negated_matcher :keep, :change


### PR DESCRIPTION
Adyen has an "at-least-once" delivery system for notifications, meaning
that we may receive the same notification multiple times. Instead of
trying to create the notification again and rescuing from the exception,
simply check if it exists and respond with accept if it does.

From the Adyen docs:
"Duplicate notifications have the same corresponding values for the
eventCode and pspReference fields."
