### PR TITLE
Add configuration class to Adyen HPP

### DIFF
--- a/config/initializers/solidus_adyen.rb
+++ b/config/initializers/solidus_adyen.rb
@@ -1,1 +1,5 @@
 Rails.application.config.assets.precompile += %w( spree/checkout/payment/adyen.js )
+
+Spree::Adyen::HPP.configure do |config|
+  config.params_class = Spree::Adyen::HPP::Params
+end

--- a/lib/spree/adyen/hpp.rb
+++ b/lib/spree/adyen/hpp.rb
@@ -7,6 +7,13 @@ module Spree
       UrlHelper = Object.new.extend ActionView::Helpers::UrlHelper
 
       class << self
+        attr_accessor :configuration
+
+        def configure
+          self.configuration ||= Spree::Adyen::HPP::Configuration.new
+          yield(configuration)
+        end
+
         def payment_methods_from_directory order, payment_method
           payment_methods(order, payment_method)
         end
@@ -49,7 +56,8 @@ module Spree
         private
         def hpp_request order, payment_method, opts
           server = payment_method.preferences.fetch(:server)
-          parameters = params(order, payment_method).merge(opts)
+          params_config = configuration.params_class.new(order, payment_method)
+          parameters = params_config.params.merge(opts)
 
           HPP::Request.new(parameters, environment: server,
                                        skin: { skin_code: payment_method.skin_code },
@@ -103,45 +111,10 @@ module Spree
           }
         end
 
-        def params order, payment_method
-          default_params.
-            merge(order_params order).
-            merge(payment_method_params payment_method).
-            merge(merchant_return_data order, payment_method)
-        end
-
-        def merchant_return_data order, payment_method
-          { merchantReturnData: [order.guest_token, payment_method.id].join("|") }
-        end
-
         def payment_method_allows_brand_code? payment_method, brand_code
           return true if payment_method.restricted_brand_codes.empty?
 
           payment_method.restricted_brand_codes.include?(brand_code)
-        end
-
-        # TODO set this in the adyen config
-        def default_params
-          { session_validity: 10.minutes.from_now,
-            recurring: false }
-        end
-
-        def order_params order
-          { currency_code: order.currency,
-            merchant_reference: order.number.to_s,
-            country_code: order.billing_address.country.iso,
-            payment_amount: (order.total * 100).to_int,
-            shopper_locale: I18n.locale.to_s.gsub("-", "_"),
-            shopper_email: order.email
-          }
-        end
-
-        def payment_method_params payment_method
-          { merchant_account: payment_method.merchant_account,
-            skin_code: payment_method.skin_code,
-            shared_secret: payment_method.shared_secret,
-            ship_before_date: payment_method.ship_before_date
-          }
         end
       end
     end

--- a/lib/spree/adyen/hpp/configuration.rb
+++ b/lib/spree/adyen/hpp/configuration.rb
@@ -1,0 +1,21 @@
+module Spree
+  module Adyen
+    module HPP
+      class Configuration
+        attr_accessor :params_class
+
+        # This class allows us to provide configuration options to the
+        # Spree::Adyen::HPP module. To add extra options, add an attr_accessor
+        # and provide a default value.
+        #
+        # Users can configure these options inside an initializer as follows:
+        #   Spree::Adyen::HPP.configure do |config|
+        #     config.params_class = Some::Custom::Class
+        #   end
+        def initialize
+          @params_class = Spree::Adyen::HPP::Params
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/adyen/hpp/params.rb
+++ b/lib/spree/adyen/hpp/params.rb
@@ -1,0 +1,54 @@
+module Spree
+  module Adyen
+    module HPP
+      class Params
+        # This class is intended to provide default parameters for HPP payment
+        # methods. To change the default behaviour, users can create a custom
+        # class that responds to #params and configure it to be used in an
+        # initializer (See Spree::Adyen::HPP::Configuration).
+
+        def initialize order, payment_method
+          @order = order
+          @payment_method = payment_method
+        end
+
+        def params
+          default_params.
+            merge(order_params).
+            merge(payment_method_params).
+            merge(merchant_return_data)
+        end
+
+        private
+
+        def default_params
+          { session_validity: 10.minutes.from_now.utc,
+            recurring: false
+          }
+        end
+
+        def merchant_return_data
+          { merchant_return_data: [@order.guest_token, @payment_method.id].join("|") }
+        end
+
+        def order_params
+          { currency_code: @order.currency,
+            merchant_reference: @order.number.to_s,
+            country_code: @order.billing_address.country.iso,
+            payment_amount: (@order.total * 100).to_int,
+            shopper_locale: I18n.locale.to_s.gsub("-", "_"),
+            shopper_email: @order.email,
+          }
+        end
+
+        def payment_method_params
+          { merchant_account: @payment_method.merchant_account,
+            skin_code: @payment_method.skin_code,
+            shared_secret: @payment_method.shared_secret,
+            ship_before_date: @payment_method.ship_before_date
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/spree/adyen/hpp_spec.rb
+++ b/spec/lib/spree/adyen/hpp_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Spree::Adyen::HPP do
-  let(:order) { create :order, total: 39.98 }
+  let(:order) { create :order, total: 39.98, guest_token: "1234" }
   let(:payment_method) { create :hpp_gateway, preferences: preferences }
   let(:preferences){
     {server: "test",
@@ -14,6 +14,51 @@ RSpec.describe Spree::Adyen::HPP do
      days_to_ship: 3}
   }
   let(:locale) { I18n.locale.to_s.gsub("-", "_") }
+
+  describe "#configuration" do
+    subject { described_class.configuration }
+
+    it { is_expected.to be_a Spree::Adyen::HPP::Configuration }
+
+    context "when no custom form params class is specified" do
+      it "uses the default class" do
+        expect(subject.params_class).to eq Spree::Adyen::HPP::Params
+      end
+    end
+
+    context "when a custom form params class is specified" do
+      before do
+        class CustomClass < Spree::Adyen::HPP::Params
+          def default_params
+            { session_validity: 1.minute.from_now.utc,
+              foo: "bar"
+            }
+          end
+        end
+
+        Spree::Adyen::HPP.configure do |config|
+          config.params_class = CustomClass
+        end
+      end
+
+      # Reset the configuration for other tests
+      after do
+        Spree::Adyen::HPP.configure do |config|
+          config.params_class = Spree::Adyen::HPP::Params
+        end
+      end
+
+      it "uses the custom class" do
+        expect(subject.params_class).to eq CustomClass
+      end
+
+      it "returns the correct params" do
+        params_config = subject.params_class.new(order, payment_method)
+        expect(params_config.params).
+          to include({ foo: "bar" })
+      end
+    end
+  end
 
   describe "directory_url" do
     let(:expected) do


### PR DESCRIPTION
We currently provide a default set of parameters that are passed to Adyen with HPP payments, but do not provide a mechanism for customizing them. Since there are a lot of optional parameters that users might want to provide in different scenarios, this will make it easier for them to configure.

Users can create a custom class that is initialized with an order and payment method and responds to `#params` and set that as the `params_class` in an initializer.  The custom class can also just inherit from the one I provided here and add or modify params as required.

We can also reuse the configuration class in the future if we need to make anything else configurable by the user.
