### PR TITLE
Show adyen notifications on CC payments

### DIFF
--- a/app/models/spree/adyen/presenters/communication.rb
+++ b/app/models/spree/adyen/presenters/communication.rb
@@ -16,6 +16,13 @@ module Spree
             map { |x| build x }
         end
 
+        def self.from_payment payment
+          notifications = AdyenNotification.where('psp_reference = ? or original_reference = ?', payment.transaction_id, payment.transaction_id)
+          (notifications + payment.log_entries).
+            sort_by(&:created_at).
+            map { |x| build x }
+        end
+
         def self.build object
           presenter_for(object).new(object)
         end

--- a/app/views/spree/admin/payments/source_views/_adyen_encrypted_cc.html.erb
+++ b/app/views/spree/admin/payments/source_views/_adyen_encrypted_cc.html.erb
@@ -1,1 +1,3 @@
 <%= render 'spree/admin/payments/source_views/gateway', payment: payment %>
+
+<%= render Spree::Adyen::Presenters::Communication.from_payment(payment) %>

--- a/spec/models/spree/adyen/presenters/communication_spec.rb
+++ b/spec/models/spree/adyen/presenters/communication_spec.rb
@@ -15,9 +15,7 @@ module Spree
           )
         end
 
-        describe "#from_source" do
-          subject { described_class.from_source source }
-
+        shared_examples_for 'communication_list' do
           it "builds a collection of presenters that all implement the interface" do
             expect(subject).
               to be_an(Array).
@@ -28,6 +26,19 @@ module Spree
                 and respond_to(:inbound?).
                 and respond_to(:fields))
           end
+        end
+
+        describe "#from_source" do
+          subject { described_class.from_source source }
+
+          it_behaves_like 'communication_list'
+        end
+
+        describe '#from_payment' do
+          let!(:payment) { create :credit_card_payment }
+          subject { described_class.from_payment payment }
+
+          it_behaves_like 'communication_list'
         end
 
         describe "#build" do


### PR DESCRIPTION
This will show the adyen notifications for CC payments, which behave
very much like HPP payments, except have a CreditCard as a source.

This will improve the life of anyone trying to investigate the state of
adyen CC payments
