### PR TITLE
Use REST API for payment requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
 # Changelog
 
 ### Unreleased changes
+
+*   Switch from using the SOAP API to the REST API for all payment requests [#91](https://github.com/StemboltHQ/solidus-adyen/pull/91)
+
+    * all payments previously used the Adyen gem's SOAP API implementation, which
+      consisted of concatenating a number of XML string partials [example](https://github.com/wvanbergen/adyen/blob/master/lib/adyen/api/templates/payment_service.rb)
+    * the SOAP implementation made it almost impossible to customize the request
+      parameters beyond those supported, but the REST API allows passing in
+      arbitrary parameters
+*   credit! now receives full `gateway_options` when called from admin/refunds_controller#create
+*   credit includes `:additional_data` in the request if it's provided in options
+*   Add `Spree::Adyen::ApiResponse` class to wrap various response classes
+    returned by the Adyen gem
+*   Add `Spree::Adyen::Client` class as an interface for making API requests

--- a/app/controllers/concerns/spree/adyen/admin/refunds_controller.rb
+++ b/app/controllers/concerns/spree/adyen/admin/refunds_controller.rb
@@ -21,7 +21,7 @@ module Spree
             return if @refund.invalid?
 
             @payment.refunds.reset # we don't want to save the refund
-            @payment.credit!(cents, currency: currency)
+            @payment.credit!(cents, @payment.gateway_options)
 
             respond
           end

--- a/app/models/concerns/spree/adyen/payment.rb
+++ b/app/models/concerns/spree/adyen/payment.rb
@@ -20,10 +20,7 @@ module Spree
           response = authorize_new_payment
 
           unless response.success?
-            response_without_xml_querier = response.dup
-            # without this sometimes YAML.load fails later
-            response_without_xml_querier.instance_variable_set("@xml_querier", nil)
-            log_entries.create!(details: response_without_xml_querier.to_yaml)
+            log_entries.create!(details: response.to_yaml)
             raise Spree::Core::GatewayError.new(
               I18n.t(:credit_card_data_refused, scope: 'solidus-adyen')
             )
@@ -149,6 +146,9 @@ module Spree
             )
           end
         end
+      rescue ::Adyen::REST::ResponseError => error
+        log_entries.create!(details: error.to_yaml)
+        raise Spree::Core::GatewayError.new(error.message)
       end
 
       def update_stored_card_data

--- a/app/models/concerns/spree/adyen/payment.rb
+++ b/app/models/concerns/spree/adyen/payment.rb
@@ -19,7 +19,7 @@ module Spree
         def authorize_payment
           response = authorize_new_payment
 
-          unless response.authorised?
+          unless response.success?
             response_without_xml_querier = response.dup
             # without this sometimes YAML.load fails later
             response_without_xml_querier.instance_variable_set("@xml_querier", nil)

--- a/app/models/concerns/spree/gateway/adyen_gateway.rb
+++ b/app/models/concerns/spree/gateway/adyen_gateway.rb
@@ -25,7 +25,7 @@ module Spree
     end
 
     def capture(amount, psp_reference, currency:, **_opts)
-      params = payment_params(amount, currency, psp_reference)
+      params = modification_request(amount, currency, psp_reference)
 
       handle_response(rest_client.capture_payment(params), psp_reference)
     end
@@ -43,7 +43,7 @@ module Spree
     def credit(amount, source = nil, psp_reference, currency: nil, **options)
       # in the case of a "refund", we don't have the full gateway_options
       currency ||= options[:originator].payment.currency
-      params = payment_params(amount, currency, psp_reference)
+      params = modification_request(amount, currency, psp_reference)
       params.merge!(options.slice(:additional_data)) if options[:additional_data]
 
       handle_response(rest_client.refund_payment(params), psp_reference)
@@ -72,7 +72,7 @@ module Spree
       )
     end
 
-    def payment_params(amount, currency, psp_reference)
+    def modification_request(amount, currency, psp_reference)
       {
         merchant_account: merchant_account,
         modification_amount: { currency: currency, value: amount },

--- a/app/models/concerns/spree/gateway/adyen_gateway.rb
+++ b/app/models/concerns/spree/gateway/adyen_gateway.rb
@@ -21,49 +21,58 @@ module Spree
     end
 
     def provider_class
-      ::Adyen::API
-    end
-
-    def provider
-      ::Adyen.configuration.api_username = api_username
-      ::Adyen.configuration.api_password = api_password
-      ::Adyen.configuration.default_api_params[:merchant_account] = merchant_account
-
-      provider_class
+      ::Adyen::REST
     end
 
     def capture(amount, psp_reference, currency:, **_opts)
-      value = { currency: currency, value: amount }
+      params = payment_params(amount, currency, psp_reference)
 
       handle_response(
-        provider.capture_payment(psp_reference, value),
+        execute_request(:capture_payment, params),
         psp_reference
       )
     end
 
     def cancel(psp_reference, _gateway_options = {})
+      params = { merchant_account: merchant_account, original_reference: psp_reference }
+
       handle_response(
-        provider.cancel_or_refund_payment(psp_reference),
+        execute_request(:cancel_or_refund_payment, params),
         psp_reference
       )
     end
 
+
     def credit(amount, source = nil, psp_reference, currency: nil, **options)
       # in the case of a "refund", we don't have the full gateway_options
       currency ||= options[:originator].payment.currency
-      amount = { currency: currency, value: amount }
+      params = payment_params(amount, currency, psp_reference)
 
       handle_response(
-        provider.refund_payment(psp_reference, amount),
+        execute_request(:refund_payment, params),
         psp_reference
       )
     end
 
     private
 
+    def rest_client
+      ::Adyen::REST::Client.new(
+        ::Adyen.configuration.environment,
+        api_username,
+        api_password
+      )
+    end
+
+    def execute_request method, params
+      ::Adyen::REST.session(rest_client) do |client|
+        client.public_send(method, params)
+      end
+    end
+
     def message response
       if response.success?
-        JSON.pretty_generate(response.params)
+        JSON.pretty_generate(response.attributes)
       else
         response.fault_message || response.params[:refusal_reason]
       end
@@ -73,9 +82,17 @@ module Spree
       ActiveMerchant::Billing::Response.new(
         response.success?,
         message(response),
-        response.params,
+        response.attributes,
         authorization: original_reference || response.psp_reference
       )
+    end
+
+    def payment_params(amount, currency, psp_reference)
+      {
+        merchant_account: merchant_account,
+        modification_amount: { currency: currency, value: amount },
+        original_reference: psp_reference,
+      }
     end
   end
 end

--- a/app/models/concerns/spree/gateway/adyen_gateway.rb
+++ b/app/models/concerns/spree/gateway/adyen_gateway.rb
@@ -55,18 +55,10 @@ module Spree
       @client ||= Adyen::Client.new(self)
     end
 
-    def message response
-      if response.success?
-        JSON.pretty_generate(response.attributes)
-      else
-        response[:refusal_reason]
-      end
-    end
-
     def handle_response(response, original_reference = nil)
       ActiveMerchant::Billing::Response.new(
         response.success?,
-        message(response),
+        response.message,
         response.attributes,
         authorization: original_reference || response.psp_reference
       )

--- a/app/models/concerns/spree/gateway/adyen_gateway.rb
+++ b/app/models/concerns/spree/gateway/adyen_gateway.rb
@@ -68,6 +68,8 @@ module Spree
       ::Adyen::REST.session(rest_client) do |client|
         client.public_send(method, params)
       end
+    rescue ::Adyen::REST::ResponseError => error
+      raise Spree::Core::GatewayError.new(error.message)
     end
 
     def message response

--- a/app/models/concerns/spree/gateway/adyen_gateway.rb
+++ b/app/models/concerns/spree/gateway/adyen_gateway.rb
@@ -74,7 +74,7 @@ module Spree
       if response.success?
         JSON.pretty_generate(response.attributes)
       else
-        response.fault_message || response.params[:refusal_reason]
+        response[:refusal_reason]
       end
     end
 

--- a/app/models/concerns/spree/gateway/adyen_gateway.rb
+++ b/app/models/concerns/spree/gateway/adyen_gateway.rb
@@ -47,6 +47,7 @@ module Spree
       # in the case of a "refund", we don't have the full gateway_options
       currency ||= options[:originator].payment.currency
       params = payment_params(amount, currency, psp_reference)
+      params.merge!(options.slice(:additional_data)) if options[:additional_data]
 
       handle_response(
         execute_request(:refund_payment, params),

--- a/app/models/spree/gateway/adyen_credit_card.rb
+++ b/app/models/spree/gateway/adyen_credit_card.rb
@@ -40,13 +40,17 @@ module Spree
 
     private
 
+    def new_credit_card? source
+      source.encrypted_data.present?
+    end
+
     def perform_authorization payment
       # If this is a new credit card we should have the encrypted data
-      if payment.source.encrypted_data
+      if new_credit_card?(payment.source)
         rest_client.authorise_recurring_payment(
           authorization_request(payment, true)
         )
-      elsif payment.source.gateway_customer_profile_id
+      elsif payment.source.has_payment_profile?
         rest_client.reauthorise_recurring_payment(
           authorization_request(payment, false)
         )

--- a/app/models/spree/gateway/adyen_credit_card.rb
+++ b/app/models/spree/gateway/adyen_credit_card.rb
@@ -19,5 +19,116 @@ module Spree
     def authorize(amount, card, gateway_options)
       ActiveMerchant::Billing::Response.new(true, "dummy authorization response")
     end
+
+    # Performs and authorization call to Adyen for the payment
+    # @raise [Spree::Core::GatewayError] if the encrypted card data is missing
+    # @raise [Spree::Core::GatewayError] if the authorize call fails
+    def authorize_new_payment payment
+      response = perform_authorization(payment)
+
+      unless response.success?
+        payment.log_entries.create!(details: response.to_yaml)
+        raise Spree::Core::GatewayError.new(
+          I18n.t(:credit_card_data_refused, scope: 'solidus-adyen')
+        )
+      end
+
+      payment.response_code = response.psp_reference
+      payment.save!
+      update_stored_card_data(payment)
+    end
+
+    private
+
+    def perform_authorization payment
+      # If this is a new credit card we should have the encrypted data
+      if payment.source.encrypted_data
+        rest_client.authorise_recurring_payment(
+          authorization_request(payment, true)
+        )
+      elsif payment.source.gateway_customer_profile_id
+        rest_client.reauthorise_recurring_payment(
+          authorization_request(payment, false)
+        )
+      else
+        raise Spree::Core::GatewayError.new(
+          I18n.t(:missing_encrypted_data, scope: 'solidus-adyen')
+        )
+      end
+    rescue Spree::Core::GatewayError => gateway_error
+      payment.log_entries.create!(details: gateway_error.to_yaml)
+      raise gateway_error
+    end
+
+    def update_stored_card_data payment
+      safe_credit_cards = get_safe_cards(payment.order)
+      return nil if safe_credit_cards.nil? || safe_credit_cards.empty?
+
+      # Ensure we use the correct card we just created
+      safe_credit_cards.sort_by! { |card| card[:creation_date] }
+      safe_credit_card_data = safe_credit_cards.last
+
+      payment.source.update(
+        gateway_customer_profile_id: safe_credit_card_data[:recurring_detail_reference],
+        cc_type: safe_credit_card_data[:variant],
+        last_digits: safe_credit_card_data[:card_number],
+        month: "%02d" % safe_credit_card_data[:card_expiry_month],
+        year: "%04d" % safe_credit_card_data[:card_expiry_year],
+        name: safe_credit_card_data[:card_holder_name]
+      )
+    end
+
+    def get_safe_cards order
+      rest_client.list_recurring_details({
+        merchant_account: merchant_account,
+        shopper_reference: reference_number_from_order(order),
+      }).details
+    end
+
+    def reference_number_from_order order
+      order.user_id.to_s || order.number
+    end
+
+    def authorization_request payment, new_card
+      request = {
+        reference: payment.order.number,
+        merchant_account: merchant_account,
+        amount: price_data(payment),
+        shopper_i_p: payment.order.last_ip_address,
+        shopper_email: payment.order.email,
+        shopper_reference: reference_number_from_order(payment.order),
+        billing_address: billing_address_from_order(payment.order),
+      }
+      request.merge!(encrypted_card_data(payment.source)) if new_card
+
+      request
+    end
+
+    def encrypted_card_data source
+      {
+        additional_data: {
+          card: { encrypted: { json: source.encrypted_data } }
+        }
+      }
+    end
+
+    def billing_address_from_order order
+      address = order.billing_address
+      {
+        street: address.address1,
+        house_number_or_name: "NA",
+        city: address.city,
+        postal_code: address.zipcode,
+        state_or_province: address.state_text || "NA",
+        country: address.country.try(:iso),
+      }
+    end
+
+    def price_data payment
+      {
+        value: payment.money.cents,
+        currency: payment.currency
+      }
+    end
   end
 end

--- a/app/models/spree/gateway/adyen_credit_card.rb
+++ b/app/models/spree/gateway/adyen_credit_card.rb
@@ -1,6 +1,6 @@
 module Spree
   class Gateway::AdyenCreditCard < Gateway
-    class ClearTextCardNumberError < StandardError; end
+    class EncryptedDataError < Spree::Core::GatewayError; end
 
     include Spree::Gateway::AdyenGateway
     preference :cse_library_location, :string
@@ -55,7 +55,7 @@ module Spree
           authorization_request(payment, false)
         )
       else
-        raise Spree::Core::GatewayError.new(
+        raise EncryptedDataError.new(
           I18n.t(:missing_encrypted_data, scope: 'solidus-adyen')
         )
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,8 @@ en:
   solidus-adyen:
     credit_card_data_refused: "The credit card data you have entered is invalid."
     missing_encrypted_data: "There was no encrypted credit card data provided."
+    profile_lookup_failed: "There was an error retrieving the user's payment profile."
+    unknown_gateway_error: "An unknown error occurred while processing your request."
     payment:
       failure: "Action failed, check reason for more information."
       success: "Action succeeded."

--- a/lib/spree/adyen/api_response.rb
+++ b/lib/spree/adyen/api_response.rb
@@ -1,0 +1,61 @@
+module Spree
+  module Adyen
+    class ApiResponse
+      attr_reader :gateway_response
+
+      def initialize gateway_response
+        @gateway_response = gateway_response
+      end
+
+      def success?
+        !error_response? && gateway_response.success?
+      end
+
+      def psp_reference
+        @gateway_response[:psp_reference]
+      end
+
+      def attributes
+        if error_response?
+          {}
+        else
+          @gateway_response.attributes
+        end
+      end
+
+      def message
+        if success?
+          JSON.pretty_generate(@gateway_response.attributes)
+        else
+          error_message
+        end
+      end
+
+      private
+
+      def authorisation_response?
+        @gateway_response.is_a?(::Adyen::REST::AuthorisePayment::Response)
+      end
+
+      def modification_response?
+        @gateway_response.is_a?(::Adyen::REST::ModifyPayment::Response)
+      end
+
+      def error_response?
+        @gateway_response.is_a?(::Adyen::REST::ResponseError)
+      end
+
+      def error_message
+        if authorisation_response?
+          @gateway_response[:refusal_reason]
+        elsif modification_response?
+          @gateway_response[:response]
+        elsif error_response?
+          @gateway_response.message
+        else
+          I18n.t(:unknown_gateway_error, scope: "solidus-adyen")
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/adyen/client.rb
+++ b/lib/spree/adyen/client.rb
@@ -1,0 +1,51 @@
+module Spree
+  module Adyen
+    class Client
+      def initialize payment_method
+        @payment_method = payment_method
+      end
+
+      def authorise_recurring_payment params
+        execute_request(:authorise_recurring_payment, params)
+      end
+
+      def reauthorise_recurring_payment params
+        execute_request(:reauthorise_recurring_payment, params)
+      end
+
+      def capture_payment params
+        execute_request(:capture_payment, params)
+      end
+
+      def refund_payment params
+        execute_request(:refund_payment, params)
+      end
+
+      def cancel_payment params
+        execute_request(:cancel_or_refund_payment, params)
+      end
+
+      def list_recurring_details params
+        execute_request(:list_recurring_details, params)
+      end
+
+      private
+
+      def client
+        @client ||= ::Adyen::REST::Client.new(
+          ::Adyen.configuration.environment,
+          @payment_method.api_username,
+          @payment_method.api_password
+        )
+      end
+
+      def execute_request method, params
+        ::Adyen::REST.session(client) do |client|
+          client.public_send(method, params)
+        end
+      rescue ::Adyen::REST::ResponseError => error
+        raise Spree::Core::GatewayError.new(error.message)
+      end
+    end
+  end
+end

--- a/lib/spree/adyen/client.rb
+++ b/lib/spree/adyen/client.rb
@@ -41,10 +41,11 @@ module Spree
 
       def execute_request method, params
         ::Adyen::REST.session(client) do |client|
-          client.public_send(method, params)
+          response = client.public_send(method, params)
+          Spree::Adyen::ApiResponse.new(response)
         end
       rescue ::Adyen::REST::ResponseError => error
-        raise Spree::Core::GatewayError.new(error.message)
+        Spree::Adyen::ApiResponse.new(error)
       end
     end
   end

--- a/lib/spree/adyen/engine.rb
+++ b/lib/spree/adyen/engine.rb
@@ -31,6 +31,9 @@ module Spree
         Spree::Order.include Spree::Adyen::Order
         Spree::Admin::RefundsController.include Spree::Adyen::Admin::RefundsController
         ::Adyen::API::PaymentService.include Spree::Adyen::PaymentService
+        ::Adyen::REST::Response.include Spree::Adyen::REST::Response
+        ::Adyen::REST::AuthorisePayment::Response.include Spree::Adyen::REST::AuthorisePaymentResponse
+        ::Adyen::REST::ModifyPayment::Response.include Spree::Adyen::REST::ModifyPaymentResponse
       end
 
       config.to_prepare(&method(:activate).to_proc)

--- a/lib/spree/adyen/rest/authorise_payment_response.rb
+++ b/lib/spree/adyen/rest/authorise_payment_response.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Adyen
+    module REST
+      module AuthorisePaymentResponse
+        def success?
+          super && authorised?
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/adyen/rest/modify_payment_response.rb
+++ b/lib/spree/adyen/rest/modify_payment_response.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Adyen
+    module REST
+      module ModifyPaymentResponse
+        def success?
+          super && received?
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/adyen/rest/response.rb
+++ b/lib/spree/adyen/rest/response.rb
@@ -1,0 +1,11 @@
+module Spree
+  module Adyen
+    module REST
+      module Response
+        def success?
+          @http_response.is_a?(Net::HTTPSuccess)
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/Credit_Card_Authorization_Process.yml
+++ b/spec/cassettes/Credit_Card_Authorization_Process.yml
@@ -223,4 +223,75 @@ http_interactions:
         xmlns="http://payment.services.adyen.com" xsi:nil="true" /><resultCode xmlns="http://payment.services.adyen.com">Authorised</resultCode></ns1:paymentResult></ns1:authoriseResponse></soap:Body></soap:Envelope>
     http_version: 
   recorded_at: Mon, 02 May 2016 15:24:22 GMT
+- request:
+    method: post
+    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
+    body:
+      encoding: US-ASCII
+      string: paymentRequest.reference=R038468844&paymentRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&paymentRequest.amount.value=2000&paymentRequest.amount.currency=USD&paymentRequest.billingAddress.street=10+Lovely+Street&paymentRequest.billingAddress.houseNumberOrName=NA&paymentRequest.billingAddress.city=Herndon&paymentRequest.billingAddress.postalCode=35005&paymentRequest.billingAddress.stateOrProvince=AL&paymentRequest.billingAddress.country=US&paymentRequest.additionalData.card.encrypted.json=adyenjs_0_1_18%24X4MGTDe1E%2BnqLcNhPTY8XYkDmWUOaiODBCn%2BxBsgPjC%2BgIQMLSCczd2q%2B84lw7MyN5BVknKhNDM0DgfoweV44zSJ9JJsJ5uNnGtSl5O6WvE13ivLdOhVEZozXiGKi1BXAX%2FFp7Jqj%2BlSiEfcRMea8qEr0iHqgUxOygeNlTwlF1cMPTYMkzCkEiJgFF5vXmml4yeyKSHIShTXTD9ODgA6qiNnRFYgY3Vsop1sP3sDTFG6O2PZkCkwS1vTVGs5FnjsmwfnU6atB3brxqclXn4RMzXH5d3Cajy9tVvEpbTeUzT%2FE5bX5U0N3NZ44MolcaomP8tlJ73qObP8hs7tij498g%3D%3D%24OnrzqA7eB8GmoTfbgGaczV9kvkquiwDGmP9V0X6XCA3C9LZCeeRRmKKbsNMSuV6bEPrFliAWVdHYayRUMaB0%2FtjGTnamrepQxp7Kg3mOEFDUYJLlPCuNVJpa5O83OLAvgrxaXvtNPmQx0qvo9WIi7ZU%2F5uU%2F2ktQum%2F3Gi6vGmjvl99TzXvUFL3tyoji8mwtmbY8M48Me7ceUEi%2BJT9RH0XNgmLUH70h0XTxRntdlMZwKZIkbYGae%2FDR%2BSq1fM2CCf9J4%2FK7hGHp6pAlAs2njJZEMeBEogTiFi0RV5HS8WtJxiJp7%2Fx8R67gQ35S4Hmu%2FzPY0SxMKPk%2FfVJ6TZlk7pvB%2FePvp9ml%2FBL0wQhMlYVTJZ1HRod6Qkt3nAPsakchBbx1aMJ%2Fa%2BZ0zfdlhBQ6dhCAM5DSqv4gibmWliCkzdfzECD0skUf%2FQQ4JW0Paxs73uYqCfJuSxVIdeMUzp0WPNPIvPeAn79cPjjjaGhxmyZuZGWJN9PDFaCfKu3tLITRONf1dE%2BZb%2BuVf6imQz5PYUPm1dWHWz2c7A1XkdbJi6zPHa6vTM2Qq26R7oEJyDF2bKFuiR%2FEBxKwg32gjTl%2FYv138e2iCxCs5I1z%2FBAgfQsG1U0XuElot8QbuLNGh9GT9aNwdlXL86sdQS8OdBj%2FLMZAPyitVJUnn1iNCuo9DWsjlidAKC2aK3IOEV5tzGVKF2tm9Y%2Bz1EtfYpdIOAOL0zlv85RmXgfWT0xOmZ3f%2BPe6102yadiiUYUuZGDFQTaR3ggJBHHNo%2Fsqfy4xXVY2C2NZdo0Q6UINTQSpghS9181pJhSm4gP03%2Bmjl%2BB4VDVL7ZVoHuLfVBmHepr6Xeyag1p%2BJfn2ChyWRuYDAx6lw6HLR0r4ptdZJOLgQh%2B%2BIoPoCfNLhMQ3k%2B%2FxM2M1IltrCn0h0dgXt3E63PfzAn%2BoT0NcxmUis%2BvsxD5IL6vPpEqZuIuhw%2Bo4fW%2B6Numa5mWytmpBv9X2946hlhwhuKyuF%2B6%2BETpbm4y3%2BmMuoQZHr2HmzCtRhX6o1UQGvbgR4ewh8T9hxPLJ7rpm7DwnpjP8I7lc62MZJfd8lpkOUX4sTh4O3%2FLz76VX2%2Bsc9z%2Bc2xxr9FCQ3SIkdesE2mewHgiR0rgMn3JrqSf57z6W1v0aanqXrwsuLLV50uAiDug3rFP%2BefjTb31NzEydyoci%2BUrLhNSUSg7E1fKN8YED0xNJ6nuG%2BBHqCjPQu0chnZ%2B10aDMXKMh65RqS9z9oqR%2F85yjXYufYl5tdCUpRz2kB%2BTbfujfASe3ldWCTbq7iHNp75X0hewmI3ySbIeHT3zOtLpwr7SCjZ9CR35c%2FgUddCg2AR55eyf6QolgC7Fvr408Okl%2Fd1v3RRLHUftha11a4gH%2FeIX64EiBluyg4Dlxp3k6ok4dngSiNAF8C%2BnEdJO3tOxiSkghnKcPqLFIIOuZ%2BAqzBnQ0W8aWBRK0AwUm7XD%2FT0wrleDoWR9ql9bn9y0ELPdPPky9qg51t9u6fNQ%2FcZOlECEKeurjMJwqKzqZgSgj%2FaPw2jAH6OaQSiox708KxAe%2Frw7cij9PGgxHN7BRwFnFaqZIkQF7DEet9MV7C0Hb%2FE11bZOTF2beWiTcOufcA%2B7Y13OO8ISipIW6QFRI0fPXSj42ALhAGACfql%2FfB1JbKy7Kg%2By30SvGXK%2F9PQqGoqzxYhbiOSApIZ6FnEyxajf6fJT9KBgTlE%2Bncv3ZHjrQ3P5RNjsD%2FJ6fFsfGHc79aYBogoD%2F785ECQzFR%2BHBXywWR4h995Bs4ZJcll3i0Kndwvk0nqUW9O%2FHnIZ984o6i176%2BxNhjTM12bOfi%2FgjJPoWLcTclIRftnMH%2Bj2YymBeB6R97oqRSlXCHn5Lxi0e5sk9odYnHLwqQcW15zSrgk5pdWB9PkbefjovPJYvSuBa3erUKQpPEU0Uzlr9LalwOzCjodhzpLC9qWvUiGO4IDWQvMRbXjh0yiE%2BzgC0VDx33bWCUMTCPWlXVmtwhBPF5sKKkjkOayb3hLlnEdbl%2FBbfHpO2i4KKX9Irzp7pSqHqnXCN7ZGmT7S%2FGEOrPIT2n495orefw4oPwX%2B%2BcsHC4WXAT9vph2g5Vtt%2FwDRrNRqmB1vhqVId7UpfU7L9Pp88HWBwIhZNVkn9bOpEXIEOHcb6ivTw3Jd%2Fw%2FEweVZyrlgEWPxQ%2BB0yUIpPZrtAhy4RM5OOzEdAzr1vYNE1KcBaD1gvovR4lVttt7JP%2F2EA9f18ofzlyM2wrHuVWeORTzfT9f%2BlYv4qvVfAn0zsD1EWfRtqSjYyEW2gsGXD8c4OAHWZhlG%2BaqNOLJX%2FHz%2B4%2BmdXzP0FdYy90V3eemXnJlX7SSsalgGAA%2FsCHwBWaPBUmC1E9Aem0TV6BXOiE7DGs2SKAFXOkEvV3I6IayId%2FkKQ%2F4IfDiiimXnBo8HiabE52XPJq%2F1Jg4j1LYTHCqSfboUoA%2FaPjrlWNS5CHjs3vVnVf0uogroOvM3U6nA4k5RHj%2BWOAucOIRKJ%2B3NIyotyq%2BppQtRDMPq%2Be1lstoOD8saOM62ngHErPm0AwTurtiXk2daFgv2%2BD9yd5oQTZdyJwA5EwXh6iGe4ff4n6KLduK8xBh9d9DdiCaUOjBmU5ueob52rDysWC%2FuKbp85dnSpDyGfxAJbRxDDl4Lr771skbSnDV%2Bd1A0YR%2FN%2FGi0EoILAg04dHglsusj8sz687y0%3D&paymentRequest.shopperIP=&paymentRequest.shopperEmail=spree%40example.com&paymentRequest.shopperReference=1&paymentRequest.recurring.contract=RECURRING&action=Payment.authorise
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Aug 2016 23:31:54 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=3BB552EACEBDD3F04DD3E6E6CF6AB82D.test4e; Path=/pal/; Secure; HttpOnly
+      Content-Length:
+      - '108'
+      Content-Type:
+      - text/plain; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: paymentResult.resultCode=Authorised&paymentResult.pspReference=8614713903144798&paymentResult.authCode=11028
+    http_version: 
+  recorded_at: Tue, 16 Aug 2016 23:31:55 GMT
+- request:
+    method: post
+    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
+    body:
+      encoding: US-ASCII
+      string: recurringDetailsRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&recurringDetailsRequest.shopperReference=1&recurringDetailsRequest.recurring.contract=RECURRING&action=Recurring.listRecurringDetails
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Aug 2016 23:31:56 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=8FA1E9591CAA6A7226AE84AA03428DCC.test104e; Path=/pal/; Secure;
+        HttpOnly
+      Content-Length:
+      - '1712'
+      Content-Type:
+      - text/plain; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: recurringDetailsResult.details.0.card.billingAddress.stateOrProvince=AL&recurringDetailsResult.details.0.variant=discover&recurringDetailsResult.details.0.card.billingAddress.houseNumberOrName=NA&recurringDetailsResult.details.0.card.holderName=John+Doe&recurringDetailsResult.details.0.aliasType=Default&recurringDetailsResult.details.0.firstPspReference=7914713873061724&recurringDetailsResult.details.0.alias=M512442788467272&recurringDetailsResult.details.0.card.expiryMonth=8&recurringDetailsResult.details.0.billingAddress.stateOrProvince=AL&recurringDetailsResult.details.0.billingAddress.street=10+Lovely+Street&recurringDetailsResult.details.0.card.billingAddress.postalCode=35005&recurringDetailsResult.details.0.card.number=6611&recurringDetailsResult.details.0.billingAddress.country=US&recurringDetailsResult.details.0.billingAddress.houseNumberOrName=NA&recurringDetailsResult.creationDate=2016-08-12T13%3A47%3A25%2B02%3A00&recurringDetailsResult.shopperReference=1&recurringDetailsResult.details.0.card.expiryYear=2018&recurringDetailsResult.details.0.paymentMethodVariant=discover&recurringDetailsResult.details.0.additionalData.cardBin=601160&recurringDetailsResult.details.0.billingAddress.postalCode=35005&recurringDetailsResult.details.0.card.billingAddress.city=Herndon&recurringDetailsResult.details.0.card.billingAddress.country=US&recurringDetailsResult.details.0.card.billingAddress.street=10+Lovely+Street&recurringDetailsResult.details.0.creationDate=2016-08-17T00%3A41%3A46%2B02%3A00&recurringDetailsResult.details.0.billingAddress.city=Herndon&recurringDetailsResult.details.0.recurringDetailReference=8314713873062304&recurringDetailsResult.lastKnownShopperEmail=spree%40example.com
+    http_version: 
+  recorded_at: Tue, 16 Aug 2016 23:31:56 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/Credit_Card_Purchase_Process.yml
+++ b/spec/cassettes/Credit_Card_Purchase_Process.yml
@@ -216,4 +216,111 @@ http_interactions:
         xmlns="http://payment.services.adyen.com">[capture-received]</response></ns1:captureResult></ns1:captureResponse></soap:Body></soap:Envelope>
     http_version: 
   recorded_at: Tue, 02 Aug 2016 18:50:54 GMT
+- request:
+    method: post
+    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
+    body:
+      encoding: US-ASCII
+      string: paymentRequest.reference=R882762483&paymentRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&paymentRequest.amount.value=2000&paymentRequest.amount.currency=USD&paymentRequest.billingAddress.street=10+Lovely+Street&paymentRequest.billingAddress.houseNumberOrName=NA&paymentRequest.billingAddress.city=Herndon&paymentRequest.billingAddress.postalCode=35005&paymentRequest.billingAddress.stateOrProvince=AL&paymentRequest.billingAddress.country=US&paymentRequest.additionalData.card.encrypted.json=adyenjs_0_1_18%24sqrkU0pVXetmCn2j0puZxOF2xG5MYvomVZrRbC4FnLDmNzsekkC2eeJnBXRiNTs8afJ6ohYeRGIc6kBAkOgKfgqDicbjKNx70xjHmApIUXv6JEAR%2BOK9W0p2SRX2xtlmHeXEuZ4l%2FgOgjDPbc0qohT5VOFFKl%2Bv24vbusqKDQ2kBkFS430AKG1eDF2UDigUo8FgqWCMeztk94r9wn%2FNm0MZ08mBF1CWfHuKlnpd6NNulM%2FVn1fhyUVOVyh5gYC17hh6K3%2F028SR94nD41ou0db1YodqhmdbivMYWfA%2BvogIxZhYJKfJ1NkoXXxMxdSK9FY3%2BFKRWa%2FsodEr1stqvAQ%3D%3D%24xgB7KuOnxOQ%2Fm8AQ1RMqBefkVdgEa83wbPUmGF%2B5poq83rUfVzLXDUaWxZxZUnz5lybXQI%2F3eM15q2c6iGY%2F14zbAymDb2H1PwZvWwFvXhCw8UbGwbDWnHCsti7btgckF4jp5ne6wxjxKDaucNMUozjLOHC7NSPf0%2Bz5yiRIEPIsBqidkI9FtTyGgU1NGwIyzvHTVVvKNW%2FOGTV1IvB6amP1WNUod0svi8Iv%2FSTLK2OFpdgQPZHeOmJ%2FhcF1wGgYWiaM1PA2lQ9mrZuLDKfrvZuR43jnnZEL6OPEc0QqqgIYs1mSuFW%2FJfg7vtktkT6ATT%2FI1NmLLYTE%2BKOTHuZ5L2BPu5pJW%2FlN7rcw8jp6y3bj2KavrN5eps6VChU1Hy5eLG4xlrik%2FnnS0UQMo0gj%2B8%2BLQhszzeqolnqcWFXZBIeNmqbMD9zFKieqC9i23lMhTa4kVgKSO4f4GL3azl9%2BHsCLB60Nk6ijXX56M2tP6aKqRVn%2BQjh3U9oSFdOcvdnpRTb6lVbHkQZDVRXeKfAOG85Ti2YhOrvs0QaDnEGBvO6qCTeqNw6rWtb2DLl2IKJP2MSSwHJd5YhjKSiMwiWnO73oDPqUoS0xLVeFi%2B36Jsi6cdsvU7KeEQrpOzX7HPW3HDy%2Bsm42KSmSbRqg2UpCG6tXoeLWy2akuxxmYouwmcctUxPek8odBYVQqPsbKxzdCTTwIR6KtGcHeeHGh2OBlrf7BosnLxisiqnqaQt6KYK7dQoUarsI%2FoKZ7P4fG1SCLTPi%2FYDVblahGlCBdG8h19S5t0VmX%2FHmqZqbH9GPTQRyKRbsSw6WBW9u8TbIP8vY80UyRVpdGAxwmkBF7l0G1Bf%2B1q5cC%2FqnMOSvlt7RLIiQo%2FQCgGA0fZgYqFQxDo%2BqC2nfotE3jA7LOvt8p9ryATlR3WlcwUt7deki%2FeNCZsbxT4LKsqnTRoc1ywJMXMsmZtIa7AXIOFhGDailTUFzHki8RmRiv6%2BvjRVNCgJbK44vOV6E9PJwm4JqXDFsEr24ziCBco1z4lCTtm8pVDaMRpcD23bBKjFG8TlNdLK0sIlM7DMxPZbTo3N%2F1Mx9E2c2zUb0pz%2FE7CFuA4nYVLBWGVdlnLj7EZNyOXMqp%2FB3aNLky1YCHlMir1uDr0r%2FjpFRAIX2Obyy0guiHVhzrMelnpQlvfZqRWPR8kQXKy2DAc%2B7qm0jZocAD8F9StbWGEsGQ9vpSMkK%2FrksfACOhTJlt4MNUfx1laba5%2FhAw5y4y6r3SH3QQvv%2FnKG9874IBzkG3KrUZP2UfGSwI6Zz1thrfDXZDIzq2o2O9yRSG9iMaJGevEcw3lVyJyU1GYR6fkS4lZN2wgHKhNO7qBPdv%2BWnNTtOfNcrp0Pmy%2Fpdg2g0dTklpNGU%2FGuNBalb0dlco4WiPZK174c7rUgP6ZmEKu0AjgaCbCBgfqFxeFen6FkIUtylI2HFBwR77w5O%2BJAOPDyK%2FD4XRD2QU5Apa3vdndrMYr1CZa95CZlTyopf0L44VL8jYyNADINeXKPoby6dE%2BK%2B%2BqjGT5yBzGcIakz8n9RdEFexoFPVa1yKVNS69e5qvSyLpRkAgLhiGBLsfMTVCHS4zb93S9wgWvz3yMZzhaOIUa9pEzXDNapsnqnG9e6%2F5AzyGtbA77xJqfcpoFgwoVAwdbxss1HX%2BjvUgmSQIcnOkbF9sFPrqZkgZeIASWQ4ynw%2B7sMpMN1bDoHUOKXBzrUDCc%2F1rNuRalkG%2BtrdjvQ0Roqmqb0Glo73kHWQyoIKCEqsKClQVfLeukCxPsA8qetAxvX8GH9bAIjDedE5jk%2B4wDqjd7kTryiFewPsVNsPtvkD9Wq%2BoSiHlY3MyYBB9uiD7XgCgOKvM9xYiwiXJRJMDQ0SbU6HAG8s4gLZ9d%2FkB9IeMK6ij8sWtdc1z5alUTUFfQ1OYmaPyC8DZLClxNXVhek6T7swAyFLo4P7CmFGpL7wUS4Itj%2BrK%2FOQo3LsVgxT8B3HHWIAsaUawELmQmY5yp9IY8%2Fovss4rrluevnX14X2n5M6BqBbRr%2Flbdr4uJrMIySkh2ci8nUlysIo1Tj1lCL7gg6y4YIqrdyJI3Ip43kDHuN2jsEue8UmM85kImNp5%2BkWc%2F8h2l5KFan9g5ArilIib%2FlN%2BW9J1ikl9OJwtHVWSPMsfx7fmIJwJPDEMKsdAkvhArSXruWT6zaSfmVGEwSBdkCvNCgx3nKq7s2EkvgUpAyGyiA3%2FZ46GNBY%2BDKE3fyKVCri%2FwG3zUrkOD0bxf%2B6kq8vmWwfP%2F3B0CPjN1eAGij6PRy%2FWmFW7Hf4fyCMnFM93yhFOIJhPlGTv2iE1aKIo%2BxAbvmFW5twfPOP%2B9bzcuuoylVcqZzBwTerV0vvV5H4eDlliY2c4fmM3ZC%2FG%2B7Owo%2Fpyl8elIyt6YaMLtuYAZQwlNJRHSzRD4iFqGALGuQpxl%2FcTbIIrVJ5JZZXULEx6Fe2iFD1%2FPn7CJzWOvtRj2bnDhaRbKsTwbhf08QwOysuqrRToW4td%2FRqzmujWPZcwCCPsf9f%2BKhiAmmqdTHS9WBRvuFSgIIoiqL8aM1uKfOV%2Bw1jRZKZ%2Bj5uPAnka%2B8MofU7D3hGJ%2FcE%2BOLavV7uHrD25KcI2XCMJlgGdIOXsT2FEKvnHrrGt6TuKF%2F1KcygO6BtkNuH8V2i3YO2FjWnNOzrkslrMBM7lx5XL89%2F8JH6FmN7DnE%3D&paymentRequest.shopperIP=&paymentRequest.shopperEmail=spree%40example.com&paymentRequest.shopperReference=1&paymentRequest.recurring.contract=RECURRING&action=Payment.authorise
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Aug 2016 23:32:01 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=B1027BC56CEAD250B055CACBBB5D500C.test104e; Path=/pal/; Secure;
+        HttpOnly
+      Content-Length:
+      - '108'
+      Content-Type:
+      - text/plain; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: paymentResult.resultCode=Authorised&paymentResult.pspReference=7914713903212586&paymentResult.authCode=81834
+    http_version: 
+  recorded_at: Tue, 16 Aug 2016 23:32:01 GMT
+- request:
+    method: post
+    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
+    body:
+      encoding: US-ASCII
+      string: recurringDetailsRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&recurringDetailsRequest.shopperReference=1&recurringDetailsRequest.recurring.contract=RECURRING&action=Recurring.listRecurringDetails
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Aug 2016 23:32:02 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=49571B99F6A5BAE1478CAF5CFB55EE09.test103e; Path=/pal/; Secure;
+        HttpOnly
+      Content-Length:
+      - '1712'
+      Content-Type:
+      - text/plain; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: recurringDetailsResult.details.0.card.billingAddress.stateOrProvince=AL&recurringDetailsResult.details.0.variant=discover&recurringDetailsResult.details.0.card.billingAddress.houseNumberOrName=NA&recurringDetailsResult.details.0.card.holderName=John+Doe&recurringDetailsResult.details.0.aliasType=Default&recurringDetailsResult.details.0.firstPspReference=7914713873061724&recurringDetailsResult.details.0.alias=M512442788467272&recurringDetailsResult.details.0.card.expiryMonth=8&recurringDetailsResult.details.0.billingAddress.stateOrProvince=AL&recurringDetailsResult.details.0.billingAddress.street=10+Lovely+Street&recurringDetailsResult.details.0.card.billingAddress.postalCode=35005&recurringDetailsResult.details.0.card.number=6611&recurringDetailsResult.details.0.billingAddress.country=US&recurringDetailsResult.details.0.billingAddress.houseNumberOrName=NA&recurringDetailsResult.creationDate=2016-08-12T13%3A47%3A25%2B02%3A00&recurringDetailsResult.shopperReference=1&recurringDetailsResult.details.0.card.expiryYear=2018&recurringDetailsResult.details.0.paymentMethodVariant=discover&recurringDetailsResult.details.0.additionalData.cardBin=601160&recurringDetailsResult.details.0.billingAddress.postalCode=35005&recurringDetailsResult.details.0.card.billingAddress.city=Herndon&recurringDetailsResult.details.0.card.billingAddress.country=US&recurringDetailsResult.details.0.card.billingAddress.street=10+Lovely+Street&recurringDetailsResult.details.0.creationDate=2016-08-17T00%3A41%3A46%2B02%3A00&recurringDetailsResult.details.0.billingAddress.city=Herndon&recurringDetailsResult.details.0.recurringDetailReference=8314713873062304&recurringDetailsResult.lastKnownShopperEmail=spree%40example.com
+    http_version: 
+  recorded_at: Tue, 16 Aug 2016 23:32:02 GMT
+- request:
+    method: post
+    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
+    body:
+      encoding: US-ASCII
+      string: modificationRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&modificationRequest.modificationAmount.currency=USD&modificationRequest.modificationAmount.value=2000&modificationRequest.originalReference=7914713903212586&action=Payment.capture
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Aug 2016 23:32:03 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=588E8BEBF3FA7C54B3CE1F4438A529D7.test4e; Path=/pal/; Secure; HttpOnly
+      Content-Length:
+      - '99'
+      Content-Type:
+      - text/plain; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: modificationResult.pspReference=8614713903234904&modificationResult.response=%5Bcapture-received%5D
+    http_version: 
+  recorded_at: Tue, 16 Aug 2016 23:32:03 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/Credit_Card_Refund.yml
+++ b/spec/cassettes/Credit_Card_Refund.yml
@@ -60,4 +60,40 @@ http_interactions:
         xmlns="http://payment.services.adyen.com">[refund-received]</response></ns1:refundResult></ns1:refundResponse></soap:Body></soap:Envelope>
     http_version: 
   recorded_at: Wed, 03 Aug 2016 21:13:22 GMT
+- request:
+    method: post
+    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
+    body:
+      encoding: US-ASCII
+      string: modificationRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&modificationRequest.modificationAmount.currency=USD&modificationRequest.modificationAmount.value=2000&modificationRequest.originalReference=7914713903212586&action=Payment.refund
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Aug 2016 23:32:12 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=1318D6B66AE5213C9755CDF694485410.test103e; Path=/pal/; Secure;
+        HttpOnly
+      Content-Length:
+      - '98'
+      Content-Type:
+      - text/plain; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: modificationResult.pspReference=8814713903329116&modificationResult.response=%5Brefund-received%5D
+    http_version: 
+  recorded_at: Tue, 16 Aug 2016 23:32:12 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/Credit_Card_not_accepted.yml
+++ b/spec/cassettes/Credit_Card_not_accepted.yml
@@ -80,4 +80,39 @@ http_interactions:
         xmlns="http://payment.services.adyen.com">Refused</resultCode></ns1:paymentResult></ns1:authoriseResponse></soap:Body></soap:Envelope>
     http_version: 
   recorded_at: Mon, 02 May 2016 15:24:16 GMT
+- request:
+    method: post
+    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
+    body:
+      encoding: US-ASCII
+      string: paymentRequest.reference=R981703707&paymentRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&paymentRequest.amount.value=2000&paymentRequest.amount.currency=USD&paymentRequest.billingAddress.street=10+Lovely+Street&paymentRequest.billingAddress.houseNumberOrName=NA&paymentRequest.billingAddress.city=Herndon&paymentRequest.billingAddress.postalCode=35005&paymentRequest.billingAddress.stateOrProvince=AL&paymentRequest.billingAddress.country=US&paymentRequest.additionalData.card.encrypted.json=adyenjs_0_1_18%24u6WAAlZ8uGGD4dphVQFdsOsmZ6vthAknRbXV7Kk8zMqgoAPh2LgARxmwhY7FFXgp8ye8wPJJz%2BWCg0lKcelv4SQeUFlN9C2kU%2Fn%2BClS1vjyLvOdRMRiloM%2FzXkFUt%2B60ZO8QsudId08ZfhDM5f%2Br5grHZ%2FlIfQYIck89xHk%2FaHEXjvKX8Ciyu3WEX%2BC12jOqvx5JHc9YqHIhY66rGpkzftURMT06XBhb807FZUrruB6QbZW6W%2BiyBLG5WJOKPXPTIMdeCVw04T5uPA1Ith9z9PKxxvr4XBWv8yHW41ZbhYPoeS7Shg5DKDy0zO9BqHLCP3%2BZr7iNCKhzJ819snK0wg%3D%3D%246iV1FGE5zBsIgNIO%2BeBB7khE8C%2B3bfCdZkAg2PiV3lvwT9GOVS6tlqC0zb9ZxQ8TkJerkSyHBlJLN3xvzNJG%2FGuGBfK0MqJUXERbe74nh8i%2FX72wos1r65rEex4HLoCAoGScDnHcv0kEAjwkT3gf08L288Iq6NnxDKchnVfLIG3ZZ1TyKEzj8DIUnx9vlia5%2F4%2FnzBoaxBUjKdO7qcxq%2B3F1lDNDnRx8XzUH%2F3lBe8D5B0OdjNbTRUTbJlpz3%2FaOzJOU8ukE7tnTmDgE43CSUaDcIqJ71MaWvtXMVDSAeK0jJCu7DRc4kYS0BqHV%2FRtV91hwSeRXCrF8%2B4g98iezO7FteIm2kUjWG7u6kJgr%2BKah3AXnHlRynuOoLw%2BVZKcIFug214QC%2FMS0gnCu4F%2BNSJ4Kf%2BN%2F9Ki4UNfWSFaCxQ8X0RytIeqO0Ar2h34gMtCcGTDKlOBup3sUUu2yLyjGdAUss7jdtvRis7PLMwckT8yUom4U1rkT158HluwFxxIBqt1W5g2iF3ozlOROheT0%2BPpGKO0OaK2c5%2BTv82kAqdoDXkQ4%2FmZj54oS1e1yCUncfMfLJLv7TNeBeF%2BR9y52Ot2y8dLZJN3ZxClWnk3AUjuoHrcsemFstjiYG5ER%2FRVgnkvQMqOCVn0M%2FAy%2B0c%2F2%2BwBzvvQSvTwlAM7pfDeS8Gra%2F33pYOZvWd69ZasXlLaVxR593Dt4eqloa657Th3uCxATujT1okRJ%2BoIAzWZUEEyXsmehGINRcLFi0AI3cio%2BzrJxfYVYcuf9ESShxv25gm1iHdlI65ZJQ6zPFPUqFU1B4cEY28vWxrnwUP2ltJnRB6bironIHzGp2sZTBB66hKWoBLOz8XtVBGY8VgP0zgtuDvx6EEOdQX0n2Z3tb6OzdxeDFho%2FaEPviJSTzCEMdk%2Bna5DYvFszqSBKzkQzzqi5q5KB0nIMkzHeckwtm6XNZkJAUTew%2BrP82hBbgmDJ19HC2IkZX%2B%2BgOwN74%2B6dcYnJidEz5VZPvWJVEIlzUzhGCo1erus7oS33akxyPJ%2BnwG%2B1Xjag%2F7QgRTjmhcSHWgFQpdPi4Qi4nQ5gKv7LglEOCuvSodhf5DOVGp2dOBl4KbXSx5KnPJLEVhu52wZ9LGNRm62qR4UHw8MBG3a6%2FvsJIXQZnvlQeF3NEKaPAtdZmnG8nOv%2FL9HQiZebOIQWW7hIELpY5dPOWq%2FUeEMXqh0O7UVnHkuAP83%2FWVSydo1ke82bIikT5zAm8EuB%2F9W%2FBuksKUx7%2Fg2wx38r5MB2tT5soqaEck2Ke6OleuGpMXyvqIyCusoo0DNifl6kPcrwJRL8TvcAoAWyRpQtaYr19i8hRCN2wuxa199kgUB2Asl27Eq%2B%2F9ISBVnkicQAmg%2FY%2Blb5bJ8a%2BtSQOcqzR2YU%2BVBOG%2FGQxE7HxhrmsWjV6OEF3pe75CvC45VjcP7v5bQMaLO7NmocQW6bN8GoTT%2BLUlr3Zk7Z8eIYnl58DofRlvxX0O5Cd39F%2BZ9klkF0UBkXRmVuXE3Crm9NbUHWyv8vQjxk%2BiMaNie08cG%2FELFVWnfnHfwwjbXryGdL4kjLYIvTr1L8WxbndmrN%2BNZdHHzQFW7ew8wnZP5EtXYWWETlzgANFwQLi22ED%2F5LH2Q7wGGSStlY01G31Qk%2F6n%2FDw1isVeu0UgG3TrueoYG4Vguu60G%2Bh17qlNn8746bQErHMsJetwFKFZt9j%2BWdYVEz2GPqPwLgL8PCRek0RTSrStV6GjZ182rlrzT91tb6R0dx1chz7wIr4TQnRxuOXT3tPnWRY6PLKnBJOrdLxzPzpN6z%2BrhjdB1%2B6rUGx63OxHkbaNlbfNxOj4WaRMw8%2FzvUwx4VVcBPkxqnkOack0tsivG180M2o2PFvp8NVG16i3%2FQeaWGtFzowgVjoQk%2F8z4i4kpV%2Fsn3RNEqh8OG3gHmsz%2FDScmFwie2eS7KHC3JTuSAosnW8bYiZAj3fFRQkf7xA%2F2Ja1mR2OlL7WHMq%2BkcYlsGwW8g5hjGoZzp5kYP%2BnlRsBa%2BmYIBfvOpRoq1QnpruehCRbHV6qzMTi7dk4OY0jxHKep%2F3PkYBRZeqMS5DkDYBYuH8uN9NcVCCajODp7o6gMHu918C5C4w%2Bxqdx3kBdI21B6zU2p3EOZ%2BRUeILYQDHuigrtGND7eyWakDyBgXuWdnTn%2F9klfhunU9SiPlkF6Kjrbqu9kb7%2BLdml392INaq%2ByFT3HF5rDLaKs6bdxAXBQh53%2Folb2qV2zoaXXeLztHdrd0Z19xfWjxEH1l%2FXSeHedhDi4XI%2BNFJdVVcKkmmLmL%2B9lFStp6ZMqYmWhPOy3IXlDqANiSHdNOiqJFXn2m6JQgLrdy5etkdFpYcI1HJZqhMtr0Kz8wy1yW7JiZ8JQzlx5%2FAYzD2j50Kr9F0DOwmgvU05tL1lN8tyvRNG5d2q5fVA1IIariGjYsGzRglB602HUOVQzoysOQ8y7v4jouuW%2BNW%2FHyUX8TRG%2Fkf1qr%2BqkM9SgQQGV3pMqUgvIsw6Uz54uGHZHZa99xndGp258jrBBjRL9oyk2VojDBkvfG33XALnRKXHfnRIlJzuuPjeAy%2BcwqJCBAFLHtgZ2H7czx3YOZgQMXXAV1Fd7de%2Ft5iwRNuxPIpxr%2FZ1TKy1VrM4L1cv%2FDS6d%2FA9rdkZB3gWGwjKDHSSIMr906bi60xhTawJES2mrBtlnbjoZjj7w%3D&paymentRequest.shopperIP=&paymentRequest.shopperEmail=spree%40example.com&paymentRequest.shopperReference=1&paymentRequest.recurring.contract=RECURRING&action=Payment.authorise
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Aug 2016 23:31:50 GMT
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=582C5DB94AE1824BAB4C451C955FE376.test3e; Path=/pal/; Secure; HttpOnly
+      Content-Length:
+      - '117'
+      Content-Type:
+      - text/plain; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: paymentResult.resultCode=Refused&paymentResult.refusalReason=CVC+Declined&paymentResult.pspReference=8514713903102276
+    http_version: 
+  recorded_at: Tue, 16 Aug 2016 23:31:50 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/adyen_capture.yml
+++ b/spec/cassettes/adyen_capture.yml
@@ -2,62 +2,37 @@
 http_interactions:
 - request:
     method: post
-    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/servlet/soap/Payment
+    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
     body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0"?>
-                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-                  <soap:Body>
-                                <payment:capture xmlns:payment="http://payment.services.adyen.com" xmlns:recurring="http://recurring.services.adyen.com" xmlns:common="http://common.services.adyen.com">
-                      <payment:modificationRequest>
-                        <payment:merchantAccount><ADYEN_MERCHANT_ACCOUNT></payment:merchantAccount>
-                        <payment:originalReference>7914483013255061</payment:originalReference>
-                                    <payment:modificationAmount>
-                      <common:currency>EUR</common:currency>
-                      <common:value>11000</common:value>
-                    </payment:modificationAmount>
-
-                      </payment:modificationRequest>
-                    </payment:capture>
-
-                  </soap:Body>
-                </soap:Envelope>
+      encoding: US-ASCII
+      string: modificationRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&modificationRequest.modificationAmount.currency=USD&modificationRequest.modificationAmount.value=11000&modificationRequest.originalReference=7914483013255061&action=Payment.capture
     headers:
-      Accept:
-      - text/xml
-      Content-Type:
-      - text/xml; charset=utf-8
-      Soapaction:
-      - authorise
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
       User-Agent:
       - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Mon, 23 Nov 2015 18:53:15 GMT
+      - Tue, 16 Aug 2016 23:32:53 GMT
       Server:
       - Apache
       Set-Cookie:
-      - JSESSIONID=60F4E60645ADD5B702F8DA2708CB7779.test4e; Path=/pal/; Secure; HttpOnly
-      Last-Modified:
-      - Mon, 23 Nov 2015 18:53:15 GMT
-      Transfer-Encoding:
-      - chunked
+      - JSESSIONID=9D4B58CC45D6C4A07E880368DEB565A7.test4e; Path=/pal/; Secure; HttpOnly
+      Content-Length:
+      - '99'
       Content-Type:
-      - text/xml;charset=UTF-8
+      - text/plain; charset=UTF-8
     body:
       encoding: UTF-8
-      string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soap:Body><ns1:captureResponse
-        xmlns:ns1="http://payment.services.adyen.com"><ns1:captureResult><additionalData
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><pspReference xmlns="http://payment.services.adyen.com">8614483047954094</pspReference><response
-        xmlns="http://payment.services.adyen.com">[capture-received]</response></ns1:captureResult></ns1:captureResponse></soap:Body></soap:Envelope>
-    http_version:
-  recorded_at: Mon, 23 Nov 2015 18:53:15 GMT
-recorded_with: VCR 2.9.3
+      string: modificationResult.pspReference=8614713903735488&modificationResult.response=%5Bcapture-received%5D
+    http_version: 
+  recorded_at: Tue, 16 Aug 2016 23:32:53 GMT
+recorded_with: VCR 3.0.1

--- a/spec/controllers/concerns/spree/adyen/admin/refunds_controller_spec.rb
+++ b/spec/controllers/concerns/spree/adyen/admin/refunds_controller_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Spree::Admin::RefundsController do
   stub_authorization!
-  include_context "mock adyen api", success: true
+  include_context "mock adyen client", success: true
   routes { Spree::Core::Engine.routes }
 
   describe "POST create" do

--- a/spec/controllers/concerns/spree/adyen/admin/refunds_controller_spec.rb
+++ b/spec/controllers/concerns/spree/adyen/admin/refunds_controller_spec.rb
@@ -40,10 +40,19 @@ RSpec.describe Spree::Admin::RefundsController do
         expect(flash[:success]).to eq "Refund request was received"
       end
 
-      it "requests the refund" do
+      it "requests the refund with full gateway options" do
         expect_any_instance_of(Spree::Payment).
           to receive(:credit!).
-          with(10000, currency: "EUR")
+          with(
+            10000,
+            hash_including({
+              currency: "EUR",
+              shipping_address: order.ship_address.active_merchant_hash,
+              billing_address: order.bill_address.active_merchant_hash,
+              email: order.email,
+              customer_id: order.user_id,
+            })
+          )
         subject
       end
 

--- a/spec/controllers/spree/adyen_notifications_controller_spec.rb
+++ b/spec/controllers/spree/adyen_notifications_controller_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Spree::AdyenNotificationsController do
-  include_context "mock adyen api", success: true
+  include_context "mock adyen client", success: true
 
   routes { Spree::Core::Engine.routes }
 

--- a/spec/controllers/spree/adyen_redirect_controller_spec.rb
+++ b/spec/controllers/spree/adyen_redirect_controller_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 # https://docs.adyen.com/display/TD/HPP+payment+response
 RSpec.describe Spree::AdyenRedirectController, type: :controller do
-  include_context "mock adyen api", success: true
+  include_context "mock adyen client", success: true
 
   let(:order) do
     create(

--- a/spec/lib/spree/adyen/api_response_spec.rb
+++ b/spec/lib/spree/adyen/api_response_spec.rb
@@ -1,0 +1,84 @@
+require "spec_helper"
+
+describe Spree::Adyen::ApiResponse do
+  let(:http_success) do
+    instance_double(
+      "Net::HTTPSuccess",
+      body: "resultCode=Authorised&pspReference=1234567890",
+    )
+  end
+  let(:http_failure) do
+    instance_double(
+      "Net::HTTPSuccess",
+      body: "resultCode=Refused&refusalReason=Denied&response=Modify failure",
+    )
+  end
+  let(:api_success) { Adyen::REST::AuthorisePayment::Response.new(http_success) }
+  let(:api_failure) { Adyen::REST::Response.new(http_failure) }
+
+  before { allow(http_success).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true) }
+  before { allow(http_failure).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true) }
+
+  describe "#psp_reference" do
+    subject { described_class.new(api_success).psp_reference }
+
+    it "returns the PSP reference from the API response" do
+      expect(subject).to eq "1234567890"
+    end
+  end
+
+  describe "#attributes" do
+    context "when the request caused a server error" do
+      let(:api_error) { Adyen::REST::ResponseError.new("BOOM") }
+
+      it "returns an empty hash" do
+        expect(described_class.new(api_error).attributes).to eq({})
+      end
+    end
+
+    context "when the request succeeded" do
+      it "returns the response attributes" do
+        expect(described_class.new(api_success).attributes).
+          to eq ({ "resultCode" => "Authorised", "pspReference" =>"1234567890" })
+      end
+    end
+  end
+
+  describe "#message" do
+    context "when the request was successful" do
+      subject { described_class.new(api_success).message }
+
+      it "returns the response attributes as JSON" do
+        expect(subject).to eq "{\n  \"resultCode\": \"Authorised\",\n  \"pspReference\": \"1234567890\"\n}"
+      end
+    end
+
+    context "when the request failed" do
+      subject { described_class.new(gateway_response).message }
+
+      context "and the request was an authorisation" do
+        let(:gateway_response) { Adyen::REST::AuthorisePayment::Response.new(http_failure) }
+
+        it "returns the refusal reason" do
+          expect(subject).to eq "Denied"
+        end
+      end
+
+      context "and the request was a modification" do
+        let(:gateway_response) { Adyen::REST::ModifyPayment::Response.new(http_failure) }
+
+        it "returns the response code" do
+          expect(subject).to eq "Modify failure"
+        end
+      end
+
+      context "and the request caused a server error" do
+        let(:gateway_response) { Adyen::REST::ResponseError.new("BOOM") }
+
+        it "returns the error message" do
+          expect(subject).to eq "API request error: BOOM"
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/spree/adyen/client_spec.rb
+++ b/spec/lib/spree/adyen/client_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe Spree::Adyen::Client do
+  shared_examples "client API request" do |method, action|
+    let(:gateway) { double("gateway", api_username: "batman", api_password: "gotham") }
+    let(:client) { instance_double("Adyen::REST::Client", close: true) }
+    let(:mock_params) { { peter: "parker" } }
+
+    subject { described_class.new(gateway) }
+
+    before { allow(subject).to receive(:client).and_return(client) }
+
+    it "calls the correct API action with the provided parameters" do
+      expect(client).to receive(action).with(peter: "parker")
+      subject.public_send(method, mock_params)
+    end
+
+    context "when the request succeeds" do
+      let(:response) { double("Mock Response") }
+      before { allow(client).to receive(action).and_return(response) }
+
+      it "returns the response" do
+        expect(subject.public_send(method, mock_params)).to eq response
+      end
+    end
+
+    context "when the request raises an adyen response error" do
+      before do
+        allow(client).to receive(action).
+          and_raise(Adyen::REST::ResponseError.new("BOOM"))
+      end
+
+      it "raises a Spree::Core::GatewayError with the correct message" do
+        expect { subject.public_send(method, mock_params) }.
+          to raise_error(Spree::Core::GatewayError, "API request error: BOOM")
+      end
+    end
+  end
+
+  describe "#authorise_recurring_payment" do
+    include_examples "client API request",
+      :authorise_recurring_payment, :authorise_recurring_payment
+  end
+
+  describe "#reauthorise_recurring_payment" do
+    include_examples "client API request",
+      :reauthorise_recurring_payment, :reauthorise_recurring_payment
+  end
+
+  describe "#capture_payment" do
+    include_examples "client API request", :capture_payment, :capture_payment
+  end
+
+  describe "#refund_payment" do
+    include_examples "client API request", :refund_payment, :refund_payment
+  end
+
+  describe "#cancel_payment" do
+    include_examples "client API request", :cancel_payment, :cancel_or_refund_payment
+  end
+
+  describe "#list_recurring_details" do
+    include_examples "client API request", :list_recurring_details, :list_recurring_details
+  end
+end

--- a/spec/models/concerns/spree/adyen/order_spec.rb
+++ b/spec/models/concerns/spree/adyen/order_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Spree::Order do
-  include_context "mock adyen api", success: true
+  include_context "mock adyen client", success: true
 
   describe "requires_manual_refund?" do
     subject { order.requires_manual_refund? }

--- a/spec/models/concerns/spree/adyen/payment_spec.rb
+++ b/spec/models/concerns/spree/adyen/payment_spec.rb
@@ -5,7 +5,7 @@ describe Spree::Adyen::Payment do
 
   shared_examples "gateway action" do
     context "when the action succeeds" do
-      include_context "mock adyen api", success: true
+      include_context "mock adyen client", success: true
 
       it "logs the response" do
         expect{ subject }.to change{ payment.reload.log_entries.count }.by(1)
@@ -18,7 +18,7 @@ describe Spree::Adyen::Payment do
 
     context "when the action fails" do
       include_context(
-        "mock adyen api",
+        "mock adyen client",
         success: false,
         fault_message: "Expected message",
       )
@@ -38,7 +38,7 @@ describe Spree::Adyen::Payment do
   end
 
   describe "#after_create" do
-    include_context "mock adyen api", success: true
+    include_context "mock adyen client", success: true
     subject { payment.save! }
 
     context "when the payment method is an Adyen credit card" do
@@ -61,7 +61,7 @@ describe Spree::Adyen::Payment do
 
         context "when the authorization fails" do
           include_context(
-            "mock adyen api",
+            "mock adyen client",
             success: false,
           )
 
@@ -116,7 +116,7 @@ describe Spree::Adyen::Payment do
     context "when the payment method is an Adyen credit card" do
       let(:payment) { create :adyen_cc_payment }
       include_context(
-        "mock adyen api",
+        "mock adyen client",
         success: true,
       )
 

--- a/spec/models/concerns/spree/adyen/payment_spec.rb
+++ b/spec/models/concerns/spree/adyen/payment_spec.rb
@@ -3,9 +3,9 @@ require "spec_helper"
 describe Spree::Adyen::Payment do
   let(:payment) { create :hpp_payment }
 
-  shared_examples "gateway action" do |klass|
+  shared_examples "gateway action" do
     context "when the action succeeds" do
-      include_context "mock adyen api", success: true, klass: klass
+      include_context "mock adyen api", success: true
 
       it "logs the response" do
         expect{ subject }.to change{ payment.reload.log_entries.count }.by(1)
@@ -21,7 +21,6 @@ describe Spree::Adyen::Payment do
         "mock adyen api",
         success: false,
         fault_message: "Expected message",
-        klass: klass,
       )
 
       it "logs the response" do
@@ -39,7 +38,7 @@ describe Spree::Adyen::Payment do
   end
 
   describe "#after_create" do
-    include_context "mock adyen api", success: true, klass: Spree::Gateway::AdyenCreditCard
+    include_context "mock adyen api", success: true
     subject { payment.save! }
 
     context "when the payment method is an Adyen credit card" do
@@ -64,8 +63,6 @@ describe Spree::Adyen::Payment do
           include_context(
             "mock adyen api",
             success: false,
-            authorised: false,
-            klass: Spree::Gateway::AdyenCreditCard
           )
 
           it "raises a gateway error and creates a log entry" do
@@ -121,7 +118,6 @@ describe Spree::Adyen::Payment do
       include_context(
         "mock adyen api",
         success: true,
-        klass: Spree::Gateway::AdyenCreditCard
       )
 
       include_examples "gateway action", Spree::Gateway::AdyenCreditCard

--- a/spec/models/concerns/spree/adyen/payment_spec.rb
+++ b/spec/models/concerns/spree/adyen/payment_spec.rb
@@ -64,6 +64,7 @@ describe Spree::Adyen::Payment do
           include_context(
             "mock adyen api",
             success: false,
+            authorised: false,
             klass: Spree::Gateway::AdyenCreditCard
           )
 
@@ -79,7 +80,7 @@ describe Spree::Adyen::Payment do
         let(:existing_card) { create :credit_card, gateway_customer_profile_id: "123ABC" }
 
         it "authorizes a recurring payment using the existing contract" do
-          expect(provider).to receive(:authorise_recurring_payment)
+          expect(client).to receive(:reauthorise_recurring_payment)
           subject
         end
       end

--- a/spec/models/concerns/spree/adyen/payment_spec.rb
+++ b/spec/models/concerns/spree/adyen/payment_spec.rb
@@ -87,7 +87,9 @@ describe Spree::Adyen::Payment do
 
       context "when no encrypted credit card data or profile is provided" do
         it "raise a gateway error" do
-          expect { subject }.to raise_error(Spree::Core::GatewayError)
+          expect { subject }.to(
+            raise_error(Spree::Gateway::AdyenCreditCard::EncryptedDataError)
+          )
         end
       end
     end

--- a/spec/models/spree/adyen/hpp_source_spec.rb
+++ b/spec/models/spree/adyen/hpp_source_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Spree::Adyen::HppSource do
-  include_context "mock adyen api", success: true
+  include_context "mock adyen client", success: true
 
   it { is_expected.to belong_to(:order) }
   it { is_expected.to have_one(:payment) }

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Spree::Adyen::NotificationProcessor do
-  include_context "mock adyen api", success: true
+  include_context "mock adyen client", success: true
 
   let!(:order) do
     # spree factories suck, it's not easy to get something to payment state

--- a/spec/models/spree/gateway/adyen_credit_card_spec.rb
+++ b/spec/models/spree/gateway/adyen_credit_card_spec.rb
@@ -152,6 +152,17 @@ describe Spree::Gateway::AdyenCreditCard do
           expect(subject.message).to eq "Should fail"
         end
       end
+
+      context "when the action causes a server error" do
+        before do
+          allow(Adyen::REST).to receive(:session).
+            and_raise(Adyen::REST::ResponseError.new("woops"))
+        end
+
+        it "raise a gateway error with the appropriate message" do
+          expect{ subject }.to raise_error(Spree::Core::GatewayError, "API request error: woops")
+        end
+      end
     end
 
     describe ".capture" do

--- a/spec/models/spree/gateway/adyen_credit_card_spec.rb
+++ b/spec/models/spree/gateway/adyen_credit_card_spec.rb
@@ -126,11 +126,9 @@ describe Spree::Gateway::AdyenCreditCard do
   context "payment modifying actions" do
     let(:gateway) { described_class.new }
 
-    include_context "mock adyen api", success: true, klass: described_class
-
     shared_examples "delayed gateway action" do
       context "when the action succeeds" do
-        include_context "mock adyen api", success: true, klass: described_class
+        include_context "mock adyen api", success: true
 
         it { is_expected.to be_a ::ActiveMerchant::Billing::Response }
 
@@ -143,24 +141,15 @@ describe Spree::Gateway::AdyenCreditCard do
         include_context(
           "mock adyen api",
           success: false,
-          fault_message: "Should fail",
-          klass: described_class
+          fault_message: "Something went wrong",
         )
 
-        it "has a response that contains the failure message" do
+        it "reports a failed status" do
           expect(subject.success?).to be false
-          expect(subject.message).to eq "Should fail"
-        end
-      end
-
-      context "when the action causes a server error" do
-        before do
-          allow(Adyen::REST).to receive(:session).
-            and_raise(Adyen::REST::ResponseError.new("woops"))
         end
 
-        it "raise a gateway error with the appropriate message" do
-          expect{ subject }.to raise_error(Spree::Core::GatewayError, "API request error: woops")
+        it "returns the error message" do
+          expect(subject.message).to eq "Something went wrong"
         end
       end
     end

--- a/spec/models/spree/gateway/adyen_credit_card_spec.rb
+++ b/spec/models/spree/gateway/adyen_credit_card_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Gateway::AdyenCreditCard do
   describe 'provider_class' do
     subject { described_class.new.provider_class }
 
-    it { is_expected.to eq(Adyen::API) }
+    it { is_expected.to eq(Adyen::REST) }
   end
 
   describe 'method_type' do

--- a/spec/models/spree/gateway/adyen_credit_card_spec.rb
+++ b/spec/models/spree/gateway/adyen_credit_card_spec.rb
@@ -128,7 +128,7 @@ describe Spree::Gateway::AdyenCreditCard do
 
     shared_examples "delayed gateway action" do
       context "when the action succeeds" do
-        include_context "mock adyen api", success: true
+        include_context "mock adyen client", success: true
 
         it { is_expected.to be_a ::ActiveMerchant::Billing::Response }
 
@@ -139,7 +139,7 @@ describe Spree::Gateway::AdyenCreditCard do
 
       context "when the action fails" do
         include_context(
-          "mock adyen api",
+          "mock adyen client",
           success: false,
           fault_message: "Something went wrong",
         )

--- a/spec/models/spree/gateway/adyen_hpp_spec.rb
+++ b/spec/models/spree/gateway/adyen_hpp_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Gateway::AdyenHPP do
 
   shared_examples "delayed gateway action" do
     context "when the action succeeds" do
-      include_context "mock adyen api", success: true
+      include_context "mock adyen client", success: true
 
       it { is_expected.to be_a ::ActiveMerchant::Billing::Response }
 
@@ -17,7 +17,7 @@ describe Spree::Gateway::AdyenHPP do
 
     context "when the action fails" do
       include_context(
-        "mock adyen api",
+        "mock adyen client",
         success: false,
         fault_message: "Should fail")
 
@@ -37,7 +37,7 @@ describe Spree::Gateway::AdyenHPP do
     subject { gateway.credit(2000, "9999", currency: "EUR") }
     include_examples "delayed gateway action"
 
-    include_context "mock adyen api", success: true
+    include_context "mock adyen client", success: true
 
     context "when additional data is provided" do
       subject { gateway.credit(2000, "9999", currency: "EUR", additional_data: "TEST") }

--- a/spec/models/spree/gateway/adyen_hpp_spec.rb
+++ b/spec/models/spree/gateway/adyen_hpp_spec.rb
@@ -47,6 +47,24 @@ describe Spree::Gateway::AdyenHPP do
   describe ".credit" do
     subject { gateway.credit(2000, "9999", currency: "EUR") }
     include_examples "delayed gateway action"
+
+    include_context "mock adyen api", success: true
+
+    context "when additional data is provided" do
+      subject { gateway.credit(2000, "9999", currency: "EUR", additional_data: "TEST") }
+
+      it "includes them in the request" do
+        expect(client).to receive(:refund_payment).with(hash_including(:additional_data))
+        subject
+      end
+    end
+
+    context "when additional data is not provided" do
+      it "is not included in the request" do
+        expect(client).to_not receive(:refund_payment).with(hash_including(:additional_data))
+        subject
+      end
+    end
   end
 
   describe ".cancel" do

--- a/spec/models/spree/gateway/adyen_hpp_spec.rb
+++ b/spec/models/spree/gateway/adyen_hpp_spec.rb
@@ -26,17 +26,6 @@ describe Spree::Gateway::AdyenHPP do
         expect(subject.message).to eq "Should fail"
       end
     end
-
-    context "when the action causes a server error" do
-      before do
-        allow(Adyen::REST).to receive(:session).
-          and_raise(Adyen::REST::ResponseError.new("woops"))
-      end
-
-      it "raise a gateway error with the appropriate message" do
-        expect{ subject }.to raise_error(Spree::Core::GatewayError, "API request error: woops")
-      end
-    end
   end
 
   describe ".capture" do

--- a/spec/support/shared_contexts/mock_adyen_api.rb
+++ b/spec/support/shared_contexts/mock_adyen_api.rb
@@ -1,86 +1,131 @@
-shared_context "mock adyen api" do |success:, fault_message: "", psp_reference: "", klass: Spree::Gateway::AdyenHPP |
+shared_context "mock adyen api" do |success:, authorised: true, received: true, fault_message: "", psp_reference: "", klass: Spree::Gateway::AdyenHPP |
   before do
-    allow_any_instance_of(klass).
-      to receive(:provider).
-      and_return provider
+    allow(Adyen::REST).
+      to receive(:session).
+      and_yield(client)
   end
 
-  let(:provider) do
+  let(:client) do
     # lambda so that this doesn't leak outside of this context.
-    mock_response = lambda do |method|
+    authorisation_response = lambda do |method|
       psp_reference ||= format "%016d", SecureRandom.random_number(10**16)
 
       instance_double(
-        "Adyen::API::PaymentService::#{method.camelcase}Response",
+        "Adyen::REST::AuthorisePayment::Response",
         success?: success,
-        fault_message: fault_message,
-        params: {
+        authorised?: authorised,
+        psp_reference: psp_reference,
+        attributes: {
           psp_reference: psp_reference,
           response: "[#{method.camelcase(:lower)}-received]"
         }
       )
     end
 
-    instance_double("Adyen::API").tap do |double|
+    modification_response = lambda do |method|
+      psp_reference ||= format "%016d", SecureRandom.random_number(10**16)
+
+      instance_double(
+        "Adyen::REST::ModifyPayment::Response",
+        success?: success,
+        received?: received,
+        psp_reference: psp_reference,
+        "[]": fault_message,
+        attributes: {
+          psp_reference: psp_reference,
+          response: "[#{method.camelcase(:lower)}-received]"
+        }
+      )
+    end
+
+    instance_double("Adyen::REST::Client").tap do |double|
       allow(double).
         to receive(:authorise_payment).
         with(
-          kind_of(String),
-          hash_including(:currency, :value),
-          hash_including(:reference, :email, :ip, :statement),
-          hash_including(:encrypted),
-          true,
-          nil,
-          false,
-          hash_including(:street, :house_number_or_name, :city, :postal_code, :state_or_province, :country)
+          hash_including(
+            :reference,
+            :merchant_account,
+            :amount,
+            :billing_address,
+            :additional_data,
+            :shopper_i_p,
+            :shopper_email,
+            :shopper_reference,
+          ),
         ).
-        and_return(mock_response.call("authorise"))
+        and_return(authorisation_response.call("authorise"))
 
       allow(double).
         to receive(:authorise_recurring_payment).
         with(
-          kind_of(String),
-          hash_including(:currency, :value),
-          hash_including(:reference, :email, :ip, :statement),
-          kind_of(String),
-          nil,
-          false,
-          hash_including(:street, :house_number_or_name, :city, :postal_code, :state_or_province, :country)
-      ).and_return(mock_response.call("authorise"))
+          hash_including(
+            :reference,
+            :merchant_account,
+            :amount,
+            :billing_address,
+            :shopper_i_p,
+            :shopper_email,
+            :shopper_reference,
+          ),
+      ).and_return(authorisation_response.call("authorise"))
+
+      allow(double).
+        to receive(:reauthorise_recurring_payment).
+        with(
+          hash_including(
+            :reference,
+            :merchant_account,
+            :amount,
+            :billing_address,
+            :shopper_i_p,
+            :shopper_email,
+            :shopper_reference,
+          ),
+      ).and_return(authorisation_response.call("authorise"))
 
       allow(double).
         to receive(:capture_payment).
         with(
-          kind_of(String),
-          hash_including(:currency, :value)
+          hash_including(
+            :merchant_account,
+            :modification_amount,
+            :original_reference,
+          ),
         ).
-        and_return(mock_response.call("capture"))
+        and_return(modification_response.call("capture"))
 
       allow(double).
         to receive(:cancel_or_refund_payment).
-        with(kind_of(String)).
-        and_return(mock_response.call("cancel_or_refund"))
+        with(
+          hash_including(
+            :merchant_account,
+            :original_reference,
+          ),
+        ).
+        and_return(modification_response.call("cancel_or_refund"))
 
       allow(double).
         to receive(:refund_payment).
         with(
-          kind_of(String),
-          hash_including(:currency, :value)
+          hash_including(
+            :merchant_account,
+            :modification_amount,
+            :original_reference,
+          ),
       ).
-      and_return(mock_response.call("refund"))
+      and_return(modification_response.call("refund"))
 
       allow(double).
         to receive(:list_recurring_details).
-        with(kind_of(String)).
+        with(hash_including(:merchant_account, :shopper_reference)).
         and_return(double("recurring details", details: [
           { creation_date: Time.parse("2016-07-29 UTC"),
             recurring_detail_reference: "AWESOMEREFERENCE",
             variant: "amex",
-            card: {
-              number: "0000",
-              expiry_date: Time.parse("2016-10-21 UTC"),
-              holder_name: "Batman Dananana",
-            },
+            card_number: "0000",
+            card_expiry_month: "10",
+            card_expiry_year: "2016",
+            card_holder_name: "Batman Dananana",
           }
         ]))
     end

--- a/spec/support/shared_contexts/mock_adyen_api.rb
+++ b/spec/support/shared_contexts/mock_adyen_api.rb
@@ -1,60 +1,39 @@
-shared_context "mock adyen api" do |success:, authorised: true, received: true, fault_message: "", psp_reference: "", klass: Spree::Gateway::AdyenHPP |
+shared_context "mock adyen api" do |success:, fault_message: "", psp_reference: "" |
   before do
-    allow(Adyen::REST).
-      to receive(:session).
-      and_yield(client)
+    allow(Spree::Adyen::Client).
+      to receive(:new).
+      and_return(client)
+  end
+
+  let(:recurring_details_response) do
+    double("recurring details", details: [
+      { creation_date: Time.parse("2016-07-29 UTC"),
+        recurring_detail_reference: "AWESOMEREFERENCE",
+        variant: "amex",
+        card_number: "0000",
+        card_expiry_month: "10",
+        card_expiry_year: "2016",
+        card_holder_name: "Batman Dananana",
+    }
+    ])
+  end
+  let(:successful_gateway_response) do
+    double("Gateway Response", success?: true)
   end
 
   let(:client) do
-    # lambda so that this doesn't leak outside of this context.
-    authorisation_response = lambda do |method|
-      psp_reference ||= format "%016d", SecureRandom.random_number(10**16)
-
+    api_response = lambda do |gateway_response|
       instance_double(
-        "Adyen::REST::AuthorisePayment::Response",
+        "Spree::Adyen::ApiResponse",
         success?: success,
-        authorised?: authorised,
+        message: fault_message,
         psp_reference: psp_reference,
-        attributes: {
-          psp_reference: psp_reference,
-          response: "[#{method.camelcase(:lower)}-received]"
-        }
+        attributes: { "resultCode" => "Authorised" },
+        gateway_response: gateway_response,
       )
     end
 
-    modification_response = lambda do |method|
-      psp_reference ||= format "%016d", SecureRandom.random_number(10**16)
-
-      instance_double(
-        "Adyen::REST::ModifyPayment::Response",
-        success?: success,
-        received?: received,
-        psp_reference: psp_reference,
-        "[]": fault_message,
-        attributes: {
-          psp_reference: psp_reference,
-          response: "[#{method.camelcase(:lower)}-received]"
-        }
-      )
-    end
-
-    instance_double("Adyen::REST::Client").tap do |double|
-      allow(double).
-        to receive(:authorise_payment).
-        with(
-          hash_including(
-            :reference,
-            :merchant_account,
-            :amount,
-            :billing_address,
-            :additional_data,
-            :shopper_i_p,
-            :shopper_email,
-            :shopper_reference,
-          ),
-        ).
-        and_return(authorisation_response.call("authorise"))
-
+    instance_double("Spree::Adyen::Client").tap do |double|
       allow(double).
         to receive(:authorise_recurring_payment).
         with(
@@ -67,7 +46,7 @@ shared_context "mock adyen api" do |success:, authorised: true, received: true, 
             :shopper_email,
             :shopper_reference,
           ),
-      ).and_return(authorisation_response.call("authorise"))
+      ).and_return(api_response.call(successful_gateway_response))
 
       allow(double).
         to receive(:reauthorise_recurring_payment).
@@ -81,7 +60,7 @@ shared_context "mock adyen api" do |success:, authorised: true, received: true, 
             :shopper_email,
             :shopper_reference,
           ),
-      ).and_return(authorisation_response.call("authorise"))
+      ).and_return(api_response.call(successful_gateway_response))
 
       allow(double).
         to receive(:capture_payment).
@@ -92,17 +71,17 @@ shared_context "mock adyen api" do |success:, authorised: true, received: true, 
             :original_reference,
           ),
         ).
-        and_return(modification_response.call("capture"))
+        and_return(api_response.call(successful_gateway_response))
 
       allow(double).
-        to receive(:cancel_or_refund_payment).
+        to receive(:cancel_payment).
         with(
           hash_including(
             :merchant_account,
             :original_reference,
           ),
         ).
-        and_return(modification_response.call("cancel_or_refund"))
+        and_return(api_response.call(successful_gateway_response))
 
       allow(double).
         to receive(:refund_payment).
@@ -113,21 +92,12 @@ shared_context "mock adyen api" do |success:, authorised: true, received: true, 
             :original_reference,
           ),
       ).
-      and_return(modification_response.call("refund"))
+      and_return(api_response.call(successful_gateway_response))
 
       allow(double).
         to receive(:list_recurring_details).
         with(hash_including(:merchant_account, :shopper_reference)).
-        and_return(double("recurring details", details: [
-          { creation_date: Time.parse("2016-07-29 UTC"),
-            recurring_detail_reference: "AWESOMEREFERENCE",
-            variant: "amex",
-            card_number: "0000",
-            card_expiry_month: "10",
-            card_expiry_year: "2016",
-            card_holder_name: "Batman Dananana",
-          }
-        ]))
+        and_return(api_response.call(recurring_details_response))
     end
   end
 end

--- a/spec/support/shared_contexts/mock_adyen_client.rb
+++ b/spec/support/shared_contexts/mock_adyen_client.rb
@@ -1,4 +1,4 @@
-shared_context "mock adyen api" do |success:, fault_message: "", psp_reference: "" |
+shared_context "mock adyen client" do |success:, fault_message: "", psp_reference: "" |
   before do
     allow(Spree::Adyen::Client).
       to receive(:new).


### PR DESCRIPTION
I ran into an issue recently where I needed to provide data along with payment requests that was not supported by the underlying Adyen gem. It turned out to be very difficult to customize the request parameters using the SOAP API implementation we currently rely on. The implementation consists largely of chunks of XML as strings appended together with data injected into them using string formatting. [Example here](https://github.com/wvanbergen/adyen/blob/master/lib/adyen/api/templates/payment_service.rb)

The Adyen gem also provides an implementation of the REST API that posts the provided params as form data. This change replaces all our API calls to use that implementation instead. Since we can provide arbitrary parameters in the request, this should make it easier to customize the request for different payment methods.
