### PR TITLE
Fix shopper reference number fallback

### DIFF
--- a/app/models/concerns/spree/adyen/payment.rb
+++ b/app/models/concerns/spree/adyen/payment.rb
@@ -184,7 +184,7 @@ module Spree
       end
 
       def reference_number_from_order
-        order.user_id.to_s || order.number
+        order.user_id.to_s.presence || order.number
       end
 
       # Solidus creates a $0 default payment during checkout using a previously
@@ -203,7 +203,7 @@ module Spree
 
       def shopper_data_from_order
         {
-          reference: order.user_id.to_s || order.number,
+          reference: reference_number_from_order,
           email: order.email,
           ip: order.last_ip_address,
           statement: order.number,


### PR DESCRIPTION
This was a bug introduced in the recent credit card changes. When
creating a recurring contract we need to provide a shopper reference
number which is supposed to unique identify the shopper. Ideally we
would always use the user ID, but in stores that support guest checkout
that may not be available.

The to_s here was turning nil into "" (empty string), so we would never
fall back to the order number. This was causing validations in the Adyen
gem to fail and would make it impossible for guest users to checkout.
