### PR TITLE
Fix shopper reference fallback again

### DIFF
--- a/app/models/spree/gateway/adyen_credit_card.rb
+++ b/app/models/spree/gateway/adyen_credit_card.rb
@@ -105,7 +105,7 @@ module Spree
     end
 
     def reference_number_from_order order
-      order.user_id.to_s || order.number
+      order.user_id.to_s.presence || order.number
     end
 
     def authorization_request payment, new_card


### PR DESCRIPTION
This was previous fixed in https://github.com/StemboltHQ/solidus-adyen/pull/92 but the authorization logic was moved to the payment method here https://github.com/StemboltHQ/solidus-adyen/pull/91. Since that PR was open before the fix, it introduced the same bug again.
