### PR TITLE
Add Adyen HPP endpoint to Spree::API

### DIFF
--- a/app/controllers/spree/api/adyen_controller.rb
+++ b/app/controllers/spree/api/adyen_controller.rb
@@ -1,0 +1,28 @@
+module Spree
+  module Api
+    class AdyenController < Spree::Api::BaseController
+      before_action :find_order
+      around_action :lock_order
+      before_action :find_payment_method
+
+      def hpp
+        @brands = Spree::Adyen::HPP.payment_methods_from_directory(
+          @order,
+          @payment_method)
+
+        render json: @brands
+      end
+
+      private
+
+      def find_order
+        @order = Spree::Order.find_by(number: order_id)
+        authorize! :read, @order, order_token
+      end
+
+      def find_payment_method
+        @payment_method = Spree::PaymentMethod.find_by(id: params[:payment_method_id])
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,10 @@ Spree::Core::Engine.routes.draw do
     end
   end
 
+  namespace :api, defaults: { format: 'json' } do
+    get "/orders/:order_id/payment_methods/:payment_method_id/adyen", to: "adyen#hpp"
+  end
+
   get "checkout/payment/adyen", to: "adyen_redirect#confirm", as: :adyen_confirmation
   post "adyen/notify", to: "adyen_notifications#notify"
   post "adyen/authorise3d", to: "adyen_redirect#authorise3d", as: :adyen_authorise3d

--- a/spec/controllers/spree/api/adyen_controller_spec.rb
+++ b/spec/controllers/spree/api/adyen_controller_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+RSpec.describe Spree::Api::AdyenController, type: :controller do
+  render_views
+
+  let(:order) { create :order }
+  let(:payment_method) { create :hpp_gateway }
+  let(:parsed_directory_response) { [{
+        name: "American Express",
+        brandCode: "amex",
+        payment_url: "www.test-payment-url.com/amex"}] }
+
+  let(:params) do
+    { order_id: order.to_param,
+      payment_method_id: payment_method.id }
+  end
+
+  before do
+    allow_any_instance_of(Spree::Ability).to receive(:can?).and_return(true)
+
+    stub_authentication!
+
+    allow(Spree::Order).to receive(:find_by!).
+      with(number: order.number).
+      and_return(order)
+
+    allow(Spree::Adyen::HPP).to receive(:payment_methods_from_directory).
+      with(order, payment_method).
+      and_return(parsed_directory_response)
+  end
+
+  subject { get action, params }
+
+  context "hpp" do
+    let(:action) { "hpp" }
+
+    before { subject }
+
+    it { expect(response.status).to eq(200) }
+
+    it { expect(response.body).to include("www.test-payment-url.com/amex") }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,9 @@ require "spree/testing_support/factories"
 require "spree/testing_support/controller_requests"
 require "spree/testing_support/url_helpers"
 require "spree/testing_support/authorization_helpers"
+require "spree/api/testing_support/helpers"
+require "spree/api/testing_support/setup"
+
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -54,6 +57,8 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::UrlHelpers
+  config.include Spree::Api::TestingSupport::Helpers, type: :controller
+  config.include Spree::Api::TestingSupport::Setup, type: :controller
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)


### PR DESCRIPTION
For applications running without solidus_frontend exposing the brand URLs within the API layer will be super useful
