### PR TITLE
Add HPP Payment API endpoint

### DIFF
--- a/app/controllers/spree/api/adyen_redirect_controller.rb
+++ b/app/controllers/spree/api/adyen_redirect_controller.rb
@@ -1,0 +1,93 @@
+module Spree
+  module Api
+    class AdyenRedirectController < Spree::Api::BaseController
+      before_action :find_order
+      around_action :lock_order
+      before_action :find_payment_method
+      before_filter :check_signature, only: :confirm
+
+      def confirm
+        if @order.complete?
+          confirm_order_already_completed
+        else
+          confirm_order_incomplete
+        end
+      end
+
+      private
+
+      def confirm_order_already_completed
+        if psp_reference
+          payment = @order.payments.find_by!(response_code: psp_reference)
+        else
+          payment = @order.payments.where(source_type: "Spree::Adyen::HppSource").last
+        end
+
+        payment.source.update(permitted_params)
+
+        respond_with(@order, default_template: 'spree/api/orders/show', status: :ok)
+      end
+
+      def confirm_order_incomplete
+        source = Adyen::HppSource.new(permitted_params)
+
+        return handle_failure unless source.authorised?
+
+        @order.payments.create!(
+          amount: @order.total,
+          payment_method: @payment_method,
+          source: source,
+          response_code: psp_reference,
+          state: "checkout"
+        )
+
+        if complete
+          respond_with(@order, default_template: 'spree/api/orders/show', status: :ok)
+        else
+          respond_with(@order, default_template: 'spree/api/orders/show', status: :unprocessable_entity)
+        end
+      end
+
+      def handle_failure
+        respond_with(@order, default_template: 'spree/api/orders/show', status: 422)
+      end
+
+      def find_order
+        @order = Spree::Order.find_by!(number: order_id)
+        authorize! :read, @order, order_token
+      end
+
+      def find_payment_method
+        _, payment_method_id = params[:merchantReturnData].split("|")
+        @payment_method = Spree::PaymentMethod.find_by!(id: payment_method_id)
+      end
+
+      def check_signature
+        unless ::Adyen::HPP::Signature.verify(permitted_params, @payment_method.shared_secret)
+          raise "Payment Method not found."
+        end
+      end
+
+      def permitted_params
+        params.permit(
+          :authResult,
+          :merchantReference,
+          :merchantReturnData,
+          :merchantSig,
+          :paymentMethod,
+          :pspReference,
+          :shopperLocale,
+          :skinCode)
+      end
+
+      def complete
+        @order.contents.advance
+        @order.complete
+      end
+
+      def psp_reference
+        params[:pspReference]
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/adyen_redirect_controller.rb
+++ b/app/controllers/spree/api/adyen_redirect_controller.rb
@@ -44,12 +44,15 @@ module Spree
         if complete
           respond_with(@order, default_template: 'spree/api/orders/show', status: :ok)
         else
-          respond_with(@order, default_template: 'spree/api/orders/show', status: :unprocessable_entity)
+          invalid_resource!(@order)
         end
       end
 
       def handle_failure
-        respond_with(@order, default_template: 'spree/api/orders/show', status: 422)
+        render json: {
+          error: I18n.t(:invalid_resource, scope: "spree.api"),
+          errors: { source: Spree.t(:payment_processing_failed) }
+        }, status: 422
       end
 
       def find_order

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,10 @@ Spree::Core::Engine.routes.draw do
     end
   end
 
+  namespace :api, defaults: { format: 'json' } do
+    post "/checkouts/:order_id/payment/adyen", to: "adyen_redirect#confirm"
+  end
+
   get "checkout/payment/adyen", to: "adyen_redirect#confirm", as: :adyen_confirmation
   post "adyen/notify", to: "adyen_notifications#notify"
   post "adyen/authorise3d", to: "adyen_redirect#authorise3d", as: :adyen_authorise3d

--- a/spec/controllers/spree/api/adyen_redirect_controller_spec.rb
+++ b/spec/controllers/spree/api/adyen_redirect_controller_spec.rb
@@ -107,11 +107,9 @@ RSpec.describe Spree::Api::AdyenRedirectController, type: :controller do
             merchant_reference: order.number)
         end
 
-        # there will already be a payment and source created at this point
-        before do
-          source =
-            create(:hpp_source, psp_reference: psp_reference, order: order)
+        let(:source) { create(:hpp_source, psp_reference: psp_reference, order: order) }
 
+        before do
           create(:hpp_payment, source: source, order: order)
 
           order.contents.advance

--- a/spec/controllers/spree/api/adyen_redirect_controller_spec.rb
+++ b/spec/controllers/spree/api/adyen_redirect_controller_spec.rb
@@ -1,0 +1,149 @@
+require "spec_helper"
+
+RSpec.describe Spree::Api::AdyenRedirectController, type: :controller do
+  include_context "mock adyen client", success: true
+
+  let(:order) do
+    create(
+      :order_with_line_items,
+      state: "payment",
+      store: store
+    )
+  end
+
+  let!(:store) { create :store }
+  let!(:gateway) { create :hpp_gateway }
+
+  before do
+    allow_any_instance_of(Spree::Ability).to receive(:can?).and_return(true)
+
+    stub_authentication!
+
+    allow(controller).to receive(:check_signature)
+
+    allow(Spree::Order).to receive(:find_by!).
+      with(number: order.number).
+      and_return(order)
+  end
+
+  subject {  }
+
+  describe "confirm" do
+    subject(:action) { post :confirm, params.reverse_merge!({ format: :json }) }
+
+    let(:psp_reference) { "8813824003752247" }
+    let(:payment_method) { "amex" }
+    let(:merchantReturnData) { "#{order.guest_token}|#{gateway.id}" }
+    let(:params) do
+      { order_id: order.number,
+        merchantReference: order.number,
+        skinCode: "xxxxxxxx",
+        shopperLocale: "en_GB",
+        paymentMethod: payment_method,
+        authResult: auth_result,
+        pspReference:  psp_reference,
+        merchantSig: "erewrwerewrewrwer",
+        merchantReturnData: merchantReturnData
+      }
+    end
+
+    shared_examples "api payment is successful" do
+      it "changes the order state to completed" do
+        subject
+        order.reload
+        expect(order).to have_attributes(
+          state: "complete",
+          payment_state: "balance_due",
+          shipment_state: "pending"
+        )
+      end
+
+      it "has pending payments" do
+        expect(order.payments).to all be_pending
+      end
+
+      it "renders an order in complete state" do
+        is_expected.to have_http_status(:ok)
+      end
+
+      it "creates a payment" do
+        subject
+        expect(order.reload.payments.count).to eq 1
+      end
+
+      context "and the order cannot complete" do
+        before do
+          expect(order).to receive(complete).and_return(false)
+        end
+
+        it "voids the payment"
+      end
+    end
+
+    shared_examples "api payment is not successful" do
+      it "does not change order state" do
+        expect{ subject }.to_not change{ order.state }
+      end
+
+      it "redirects to the order payment page" do
+        is_expected.to have_http_status(422)
+      end
+    end
+
+    context "when the payment is AUTHORISED" do
+      include_examples "api payment is successful"
+
+      let(:auth_result) { "AUTHORISED" }
+
+      context "and the authorisation notification has already been received" do
+        let(:payment_method) { notification.payment_method }
+
+        let(:notification) do
+          create(
+            :notification,
+            :auth,
+            processed: true,
+            psp_reference: psp_reference,
+            merchant_reference: order.number)
+        end
+
+        # there will already be a payment and source created at this point
+        before do
+          source =
+            create(:hpp_source, psp_reference: psp_reference, order: order)
+
+          create(:hpp_payment, source: source, order: order)
+
+          order.contents.advance
+          order.complete
+        end
+
+        it { expect { subject }.to_not change { order.payments.count }.from 1 }
+
+        it "updates the source" do
+          expect(order.payments.last.source).to have_attributes(
+            auth_result: "AUTHORISED",
+            skin_code: "XXXXXXXX"
+          )
+        end
+
+        include_examples "api payment is successful"
+      end
+    end
+
+    context "when the payment is PENDING" do
+      include_examples "api payment is successful"
+      let(:auth_result) { "PENDING" }
+    end
+
+    context "when the payment is CANCELLED" do
+      include_examples "api payment is not successful"
+      let(:auth_result) { "CANCELLED" }
+    end
+
+    context "when the payment is REFUSED" do
+      include_examples "api payment is not successful"
+      let(:auth_result) { "REFUSED" }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,8 @@ require "spree/testing_support/factories"
 require "spree/testing_support/controller_requests"
 require "spree/testing_support/url_helpers"
 require "spree/testing_support/authorization_helpers"
+require "spree/api/testing_support/helpers"
+require "spree/api/testing_support/setup"
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -54,6 +56,8 @@ RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::UrlHelpers
+  config.include Spree::Api::TestingSupport::Helpers, type: :controller
+  config.include Spree::Api::TestingSupport::Setup, type: :controller
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,6 +59,14 @@ RSpec.configure do |config|
   config.include Spree::Api::TestingSupport::Helpers, type: :controller
   config.include Spree::Api::TestingSupport::Setup, type: :controller
 
+  if Object.const_defined?('VersionCake')
+    config.include VersionCake::TestHelpers, type: :controller
+
+    config.before(:each, type: :controller) do
+      set_request_version('', 1)
+    end
+  end
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end


### PR DESCRIPTION
In order to support `solidus_api` backed frontend only applications (React/Angular/Ember etc) delegating the responsibility of the payment processing, and keeping a single "source of truth" for processing is desired.

This PR adds a RESTful checkout endpoint that can be targetted by applications of this nature to POST on the get request from Adyen.
