### PR TITLE
Integrate Ratepay invoice payments through Adyen's API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,14 @@
 source "https://rubygems.org"
 
+branch = ENV.fetch("SOLIDUS_BRANCH", "master")
+if branch == "master" || branch >= "v2.0"
+  gem "rails-controller-testing", group: :test
+end
+
 group :development, :test do
-  gem "solidus"
+  gem "solidus", github: 'solidusio/solidus', branch: branch
   gem "solidus_auth_devise"
+
 
   gem "pg"
   gem "mysql2"

--- a/app/models/concerns/spree/adyen/payment.rb
+++ b/app/models/concerns/spree/adyen/payment.rb
@@ -9,12 +9,12 @@ module Spree
       include Spree::Adyen::PaymentCheck
 
       included do
-        after_create :authorize_adyen_credit_card, if: :authorizable_cc_payment?
+        after_create :authorise_on_create, if: :should_authorise?
 
         private
 
-        def authorize_adyen_credit_card
-          payment_method.authorize_new_payment(self)
+        def authorise_on_create
+          payment_method.authorise_new_payment(self)
         end
       end
 
@@ -113,8 +113,8 @@ module Spree
 
       # Solidus creates a $0 default payment during checkout using a previously
       # used credit card, which we should not create an authorization for.
-      def authorizable_cc_payment?
-        adyen_cc_payment? && amount != 0
+      def should_authorise?
+        (adyen_cc_payment? || ratepay?) && amount != 0
       end
     end
   end

--- a/app/models/concerns/spree/adyen/payment.rb
+++ b/app/models/concerns/spree/adyen/payment.rb
@@ -22,7 +22,7 @@ module Spree
       # auto_capture enabled. Since we authorize credit cards in the payment
       # step already, we just need to capture the payment here.
       def purchase!
-        if adyen_cc_payment?
+        if adyen_cc_payment? || ratepay?
           capture!
         else
           super
@@ -31,7 +31,7 @@ module Spree
 
       # capture! :: bool | error
       def capture!
-        if hpp_payment? || adyen_cc_payment?
+        if hpp_payment? || adyen_cc_payment? || ratepay?
           amount = money.money.cents
           process do
             payment_method.send(

--- a/app/models/spree/adyen/presenters/communication.rb
+++ b/app/models/spree/adyen/presenters/communication.rb
@@ -7,6 +7,7 @@ module Spree
         PRESENTERS = [
           ::Spree::Adyen::Presenters::Communications::AdyenNotification,
           ::Spree::Adyen::Presenters::Communications::HppSource,
+          ::Spree::Adyen::Presenters::Communications::RatepaySource,
           ::Spree::Adyen::Presenters::Communications::LogEntry
         ].freeze
 

--- a/app/models/spree/adyen/presenters/communications/ratepay_source.rb
+++ b/app/models/spree/adyen/presenters/communications/ratepay_source.rb
@@ -1,0 +1,31 @@
+module Spree
+  module Adyen
+    module Presenters
+      module Communications
+        class RatepaySource < ::Spree::Adyen::Presenters::Communications::Base
+          def fields
+            { result: auth_result,
+              payment_method: payment_method
+            }
+          end
+
+          def success?
+            true
+          end
+
+          def processed?
+            true
+          end
+
+          def inbound?
+            true
+          end
+
+          def self.applicable? obj
+            obj.is_a? Spree::Adyen::RatepaySource
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/spree/adyen/ratepay_source.rb
+++ b/app/models/spree/adyen/ratepay_source.rb
@@ -11,9 +11,18 @@ module Spree
 
       attr_accessor :dob_day, :dob_month, :dob_year
 
-      # Adyen require
+      # Formats the date of birth fields how they are accepted by Adyen
+      #
+      # @return [String] The DOB in the format yyyy-dd-mm
       def date_of_birth
         "#{dob_year}-#{dob_day}-#{dob_month}"
+      end
+
+      # Checks if all the date of birth fields have been set
+      #
+      # @return [Bool] true if all DOB fields are set, false otherwise
+      def has_dob?
+        [dob_day, dob_month, dob_year].all?(&:present?)
       end
     end
   end

--- a/app/models/spree/adyen/ratepay_source.rb
+++ b/app/models/spree/adyen/ratepay_source.rb
@@ -1,0 +1,13 @@
+module Spree
+  module Adyen
+    class RatepaySource < ::ActiveRecord::Base
+      belongs_to :payment_method
+      belongs_to :user, class_name: Spree.user_class, foreign_key: "user_id"
+      has_one :payment, class_name: "Spree::Payment", as: :source
+      has_many :notifications,
+        class_name: "AdyenNotification",
+        foreign_key: :merchant_reference,
+        primary_key: :merchant_reference
+    end
+  end
+end

--- a/app/models/spree/adyen/ratepay_source.rb
+++ b/app/models/spree/adyen/ratepay_source.rb
@@ -8,6 +8,13 @@ module Spree
         class_name: "AdyenNotification",
         foreign_key: :merchant_reference,
         primary_key: :merchant_reference
+
+      attr_accessor :dob_day, :dob_month, :dob_year
+
+      # Adyen require
+      def date_of_birth
+        "#{dob_year}-#{dob_day}-#{dob_month}"
+      end
     end
   end
 end

--- a/app/models/spree/adyen/ratepay_source.rb
+++ b/app/models/spree/adyen/ratepay_source.rb
@@ -9,7 +9,7 @@ module Spree
         foreign_key: :merchant_reference,
         primary_key: :merchant_reference
 
-      attr_accessor :dob_day, :dob_month, :dob_year
+      attr_accessor :dob_day, :dob_month, :dob_year, :device_token
 
       # Formats the date of birth fields how they are accepted by Adyen
       #

--- a/app/models/spree/gateway/adyen_credit_card.rb
+++ b/app/models/spree/gateway/adyen_credit_card.rb
@@ -39,7 +39,7 @@ module Spree
     # Performs and authorization call to Adyen for the payment
     # @raise [Spree::Core::GatewayError] if the encrypted card data is missing
     # @raise [Spree::Core::GatewayError] if the authorize call fails
-    def authorize_new_payment payment
+    def authorise_new_payment payment
       response = perform_authorization(payment)
 
       unless response.success?

--- a/app/models/spree/gateway/adyen_ratepay.rb
+++ b/app/models/spree/gateway/adyen_ratepay.rb
@@ -1,0 +1,20 @@
+module Spree
+  class Gateway::AdyenRatepay < Spree::Gateway
+    include Spree::Gateway::AdyenGateway
+
+    def method_type
+      "adyen_ratepay"
+    end
+
+    def payment_source_class
+      Adyen::RatepaySource
+    end
+
+    def authorize(amount, source, gateway_options)
+      # We need to authorise Ratepay payments on the `payment` checkout step,
+      # so that we don't need to persist the user's date of birth. Once we hit
+      # this the payment should already be authorized.
+      ActiveMerchant::Billing::Response.new(true, "successful Ratepay authorization")
+    end
+  end
+end

--- a/app/models/spree/gateway/adyen_ratepay.rb
+++ b/app/models/spree/gateway/adyen_ratepay.rb
@@ -1,5 +1,13 @@
 module Spree
   class Gateway::AdyenRatepay < Spree::Gateway
+    class InvoiceRejectedError < Spree::Core::GatewayError; end
+
+    class MissingDateOfBirthError < Spree::Core::GatewayError
+      def message
+        I18n.t(:missing_date_of_birth, scope: "solidus-adyen")
+      end
+    end
+
     include Spree::Gateway::AdyenGateway
 
     def method_type
@@ -15,6 +23,38 @@ module Spree
       # so that we don't need to persist the user's date of birth. Once we hit
       # this the payment should already be authorized.
       ActiveMerchant::Billing::Response.new(true, "successful Ratepay authorization")
+    end
+
+    def authorise_new_payment(payment)
+      raise MissingDateOfBirthError unless payment.source.has_dob?
+
+      response = perform_authorisation(payment)
+      if response.success?
+        payment.source.update!(
+          auth_result: response.gateway_response.result_code,
+          psp_reference: response.psp_reference,
+          merchant_reference: payment.order.number
+        )
+        payment.update!(response_code: response.psp_reference)
+      else
+        payment.log_entries.create!(details: response.to_yaml)
+        raise InvoiceRejectedError, response.message
+      end
+    end
+
+    private
+
+    def perform_authorisation payment
+      params = Spree::Adyen::HPP.
+        configuration.
+        params_class.new(payment.order, self).
+        authorise_invoice(payment.source.date_of_birth).
+        merge({
+          device_fingerprint: "4R8Pay",
+          selected_brand: "ratepay_#{payment.order.bill_address.country.iso}"
+        })
+
+      Spree::Adyen::Client.new(self).authorise_payment(params)
     end
   end
 end

--- a/app/models/spree/gateway/adyen_ratepay.rb
+++ b/app/models/spree/gateway/adyen_ratepay.rb
@@ -10,6 +10,12 @@ module Spree
 
     include Spree::Gateway::AdyenGateway
 
+    preference :device_sid, :string
+
+    def device_sid
+      ENV["RATEPAY_DEVICE_SID"] || preferred_device_sid
+    end
+
     def method_type
       "adyen_ratepay"
     end
@@ -50,7 +56,7 @@ module Spree
         params_class.new(payment.order, self).
         authorise_invoice(payment.source.date_of_birth).
         merge({
-          device_fingerprint: "4R8Pay",
+          device_fingerprint: payment.source.device_token,
           selected_brand: "ratepay_#{payment.order.bill_address.country.iso}"
         })
 

--- a/app/views/spree/admin/payments/source_forms/_adyen_ratepay.html.erb
+++ b/app/views/spree/admin/payments/source_forms/_adyen_ratepay.html.erb
@@ -1,0 +1,1 @@
+Cannot create Ratepay payments on the backend.

--- a/app/views/spree/admin/payments/source_views/_adyen_ratepay.html.erb
+++ b/app/views/spree/admin/payments/source_views/_adyen_ratepay.html.erb
@@ -1,0 +1,14 @@
+<% content_for :page_actions do %>
+  <li>
+    <%=
+      link_to "View in Customer Area",
+        Spree::Adyen::URL.payment_adyen_customer_area_url(
+          merchant_account: payment.payment_method.preferred_merchant_account,
+          psp_reference: payment.response_code
+        ),
+        class: "button fa"
+    %>
+  </li>
+<% end %>
+
+<%= render Spree::Adyen::Presenters::Communication.from_source(payment.source) %>

--- a/app/views/spree/checkout/payment/_adyen_ratepay.html.erb
+++ b/app/views/spree/checkout/payment/_adyen_ratepay.html.erb
@@ -5,35 +5,38 @@
 <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
 <%= hidden_field_tag "#{param_prefix}[device_token]", device_token %>
-<div class="adyen-ratepay field">
-  <%= label_tag nil, Spree.t(:date_of_birth_day) %><span class="required">*</span><br />
-  <%= text_field_tag "#{param_prefix}[dob_day]", nil,
-    class: "required",
-    autocomplete: "off",
-    size: 2,
-    maxlength: 2
-  %>
-</div>
+<fieldset>
+  <legend><%= Spree.t(:date_of_birth) %></legend>
+  <div class="adyen-ratepay field">
+    <%= label_tag nil, Spree.t(:day) %><span class="required">*</span><br />
+    <%= text_field_tag "#{param_prefix}[dob_day]", nil,
+      class: "required",
+      autocomplete: "off",
+      size: 2,
+      maxlength: 2
+    %>
+  </div>
 
-<div class="adyen-ratepay field">
-  <%= label_tag nil, Spree.t(:date_of_birth_month) %><span class="required">*</span><br />
-  <%= text_field_tag "#{param_prefix}[dob_month]", nil,
-    class: "required",
-    autocomplete: "off",
-    size: 2,
-    maxlength: 2
-  %>
-</div>
+  <div class="adyen-ratepay field">
+    <%= label_tag nil, Spree.t(:month) %><span class="required">*</span><br />
+    <%= text_field_tag "#{param_prefix}[dob_month]", nil,
+      class: "required",
+      autocomplete: "off",
+      size: 2,
+      maxlength: 2
+    %>
+  </div>
 
-<div class="adyen-ratepay field">
-  <%= label_tag nil, Spree.t(:date_of_birth_year) %><span class="required">*</span><br />
-  <%= text_field_tag "#{param_prefix}[dob_year]", nil,
-    class: "required",
-    autocomplete: "off",
-    size: 4,
-    maxlength: 4
-  %>
-</div>
+  <div class="adyen-ratepay field">
+    <%= label_tag nil, Spree.t(:year) %><span class="required">*</span><br />
+    <%= text_field_tag "#{param_prefix}[dob_year]", nil,
+      class: "required",
+      autocomplete: "off",
+      size: 4,
+      maxlength: 4
+    %>
+  </div>
+</fieldset>
 
 <!-- This JavaScript is provided by Ratepay for their device fingerprinting -->
 <script language="JavaScript">

--- a/app/views/spree/checkout/payment/_adyen_ratepay.html.erb
+++ b/app/views/spree/checkout/payment/_adyen_ratepay.html.erb
@@ -1,5 +1,10 @@
+<!-- Ratepay requires us to generate a unique token for each device on checkout -->
+<% device_sid = payment_method.device_sid %>
+<% device_token = Digest::SHA256.hexdigest(@order.number + DateTime.now.to_s) %>
+
 <% param_prefix = "payment_source[#{payment_method.id}]" %>
 
+<%= hidden_field_tag "#{param_prefix}[device_token]", device_token %>
 <div class="adyen-ratepay field">
   <%= label_tag nil, Spree.t(:date_of_birth_day) %><span class="required">*</span><br />
   <%= text_field_tag "#{param_prefix}[dob_day]", nil,
@@ -29,3 +34,19 @@
     maxlength: 4
   %>
 </div>
+
+<!-- This JavaScript is provided by Ratepay for their device fingerprinting -->
+<script language="JavaScript">
+  var di = {
+    t:'<%= device_token %>',
+    v:'<%= device_sid %>',
+    l:'Checkout'
+  };
+</script>
+<script type="text/javascript" src="//d.ratepay.com/<%= device_sid %>/di.js"></script>
+<noscript><link rel="stylesheet" type="text/css" href="//d.ratepay.com/di.css?t=<%= device_token %>&v=<%= device_sid %>&l=Checkout"></noscript>
+<object type="application/x-shockwave-flash" data="//d.ratepay.com/<%= device_sid %>/c.swf" width="0" height="0">
+  <param name="movie" value="//d.ratepay.com/<%= device_sid %>/c.swf" />
+  <param name="flashvars" value="t=<%= device_token %>&v=<%= device_sid %>"/>
+  <param name="AllowScriptAccess" value="always"/>
+</object>

--- a/app/views/spree/checkout/payment/_adyen_ratepay.html.erb
+++ b/app/views/spree/checkout/payment/_adyen_ratepay.html.erb
@@ -1,0 +1,31 @@
+<% param_prefix = "payment_source[#{payment_method.id}]" %>
+
+<div class="adyen-ratepay field">
+  <%= label_tag nil, Spree.t(:date_of_birth_day) %><span class="required">*</span><br />
+  <%= text_field_tag "#{param_prefix}[dob_day]", nil,
+    class: "required",
+    autocomplete: "off",
+    size: 2,
+    maxlength: 2
+  %>
+</div>
+
+<div class="adyen-ratepay field">
+  <%= label_tag nil, Spree.t(:date_of_birth_month) %><span class="required">*</span><br />
+  <%= text_field_tag "#{param_prefix}[dob_month]", nil,
+    class: "required",
+    autocomplete: "off",
+    size: 2,
+    maxlength: 2
+  %>
+</div>
+
+<div class="adyen-ratepay field">
+  <%= label_tag nil, Spree.t(:date_of_birth_year) %><span class="required">*</span><br />
+  <%= text_field_tag "#{param_prefix}[dob_year]", nil,
+    class: "required",
+    autocomplete: "off",
+    size: 4,
+    maxlength: 4
+  %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
           amount: "Amount"
   solidus-adyen:
     credit_card_data_refused: "The credit card data you have entered is invalid."
+    missing_date_of_birth: "Date of birth is required for invoice transactions."
     missing_encrypted_data: "There was no encrypted credit card data provided."
     profile_lookup_failed: "There was an error retrieving the user's payment profile."
     unknown_gateway_error: "An unknown error occurred while processing your request."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,10 @@
 ---
 en:
   spree:
+    date_of_birth: Date of Birth
+    day: Day
+    month: Month
+    year: Year
     adyen:
       communication:
         communication:

--- a/db/migrate/20160927175452_create_spree_adyen_ratepay_sources.rb
+++ b/db/migrate/20160927175452_create_spree_adyen_ratepay_sources.rb
@@ -1,0 +1,16 @@
+class CreateSpreeAdyenRatepaySources < ActiveRecord::Migration
+  def change
+    create_table :spree_adyen_ratepay_sources do |t|
+      t.string :auth_result
+      t.string :psp_reference
+      t.string :merchant_reference
+      t.integer :payment_method_id, foreign_key: { references: :spree_payment_methods }, index: { name: 'index_ratepay_source_payment_method' }
+      t.integer :user_id, foreign_key: { references: :spree_users }, index: true
+
+      t.timestamps null: false
+    end
+
+    add_index :spree_adyen_ratepay_sources, :psp_reference, unique: true
+    add_index :spree_adyen_ratepay_sources, :merchant_reference
+  end
+end

--- a/lib/spree/adyen/client.rb
+++ b/lib/spree/adyen/client.rb
@@ -5,6 +5,10 @@ module Spree
         @payment_method = payment_method
       end
 
+      def authorise_payment params
+        execute_request(:authorise_payment, params)
+      end
+
       def authorise_recurring_payment params
         execute_request(:authorise_recurring_payment, params)
       end

--- a/lib/spree/adyen/engine.rb
+++ b/lib/spree/adyen/engine.rb
@@ -23,6 +23,7 @@ module Spree
         Spree::PermittedAttributes.source_attributes << :dob_day
         Spree::PermittedAttributes.source_attributes << :dob_month
         Spree::PermittedAttributes.source_attributes << :dob_year
+        Spree::PermittedAttributes.source_attributes << :device_token
       end
 
       # The Adyen gem doesn't provide a way to pass the shopper's billing

--- a/lib/spree/adyen/engine.rb
+++ b/lib/spree/adyen/engine.rb
@@ -19,6 +19,7 @@ module Spree
       initializer "spree.solidus-adyen.payment_methods", after: "spree.register.payment_methods" do |app|
         app.config.spree.payment_methods << Gateway::AdyenHPP
         app.config.spree.payment_methods << Gateway::AdyenCreditCard
+        app.config.spree.payment_methods << Gateway::AdyenRatepay
         Spree::PermittedAttributes.source_attributes << :dob_day
         Spree::PermittedAttributes.source_attributes << :dob_month
         Spree::PermittedAttributes.source_attributes << :dob_year

--- a/lib/spree/adyen/engine.rb
+++ b/lib/spree/adyen/engine.rb
@@ -19,6 +19,9 @@ module Spree
       initializer "spree.solidus-adyen.payment_methods", after: "spree.register.payment_methods" do |app|
         app.config.spree.payment_methods << Gateway::AdyenHPP
         app.config.spree.payment_methods << Gateway::AdyenCreditCard
+        Spree::PermittedAttributes.source_attributes << :dob_day
+        Spree::PermittedAttributes.source_attributes << :dob_month
+        Spree::PermittedAttributes.source_attributes << :dob_year
       end
 
       # The Adyen gem doesn't provide a way to pass the shopper's billing

--- a/lib/spree/adyen/hpp/configuration.rb
+++ b/lib/spree/adyen/hpp/configuration.rb
@@ -2,7 +2,7 @@ module Spree
   module Adyen
     module HPP
       class Configuration
-        attr_accessor :params_class
+        attr_accessor :params_class, :invoice_class
 
         # This class allows us to provide configuration options to the
         # Spree::Adyen::HPP module. To add extra options, add an attr_accessor
@@ -14,6 +14,7 @@ module Spree
         #   end
         def initialize
           @params_class = Spree::Adyen::HPP::Params
+          @invoice_class = Spree::Adyen::Invoice
         end
       end
     end

--- a/lib/spree/adyen/hpp/params.rb
+++ b/lib/spree/adyen/hpp/params.rb
@@ -111,7 +111,7 @@ module Spree
         end
 
         def openinvoice_params
-          Spree::Adyen::Invoice.new(@order).request_params
+          Spree::Adyen::HPP.configuration.invoice_class.new(@order).request_params
         end
       end
     end

--- a/lib/spree/adyen/invoice.rb
+++ b/lib/spree/adyen/invoice.rb
@@ -1,0 +1,113 @@
+module Spree
+  module Adyen
+    class Invoice
+      # We store tax percent as a fraction (19% = 0.19)
+      # This is the ratio to convert the fraction to minor units
+      FRACTION_TO_MINOR_UNITS = 10000.freeze
+
+      def initialize order
+        @order = order
+      end
+
+      # Generates the invoice line parameters Adyen requires in order to process
+      # invoice type payments.
+      # For more information see: https://docs.adyen.com/developers/open-invoice-manual
+      #
+      # @return [Hash] Hash containing the invoice lines for the order
+      def request_params
+        params = {
+          openinvoicedata: {
+            number_of_lines: @order.line_items.count,
+            refund_description: "Refund for #{@order.number}"
+          }
+        }
+
+        @order.line_items.each_with_index do |item, index|
+          params[:openinvoicedata]["line#{index + 1}"] = {
+            currency_code: item.currency,
+            description: line_item_name(item),
+            item_amount: pre_tax_amount_from_line_item(item),
+            item_vat_amount: vat_amount_from_line_item(item),
+            item_vat_percentage: vat_percent_from_line_item(item),
+            line_reference: index + 1,
+            number_of_items: item.quantity,
+            vat_category: "High"
+          }
+        end
+
+        params
+      end
+
+      private
+
+      # Generate the name to display on the invoice for a given line item. Since
+      # the name should uniquely identify it, this includes the option value
+      # names for the case where we have the two of the same item with
+      # different options.
+      #
+      # @params [Spree::LineItem] line_item the item to generate a name for
+      # @return [String] the name to display on the invoice for the line item
+      def line_item_name line_item
+        option_values_text = line_item.variant.option_values.map(&:presentation).join(" ")
+        [line_item.product.name, option_values_text].join(" ")
+      end
+
+      # Compute the pre-tax amount for a single unit within a line item.
+      # Since the pre-tax amount and the included tax amount must always add up
+      # to the total, we round this down and the included tax amount up. This
+      # is the same way Solidus rounds and should avoid rounding errors.
+      #
+      # @param [Spree::LineItem] line_item the line item to compute the amount for
+      # @return [Fixnum] The pre-tax amount in cents
+      def pre_tax_amount_from_line_item line_item
+        amount = (line_item.discounted_amount - line_item.included_tax_total) / line_item.quantity
+
+        Spree::Money.new(
+          BigDecimal.new(amount.to_s).round(2, BigDecimal::ROUND_HALF_DOWN),
+          currency: line_item.currency
+        ).cents
+      end
+
+      # Compute the total VAT percentage applied to the line item by summing all
+      # the included tax adjustments applied to it.
+      # Adyen requires the VAT percentage in "minor units"
+      # ie: 19% VAT => 1900
+      #
+      # @param [Spree::LineItem] line_item the line item to compute the VAT % for
+      # @return [Fixnum] the VAT % in minor units
+      def vat_percent_from_line_item line_item
+        (sum_of_tax_rates(line_item) * FRACTION_TO_MINOR_UNITS).to_i
+      end
+
+      # Compute the VAT amount for a single unit within a line item.
+      # We store included_tax_total per line item, which may have quantity > 1
+      # and using that value may result in off-by-one errors
+      #
+      # @param [Spree::LineItem] line_item the line item to compute the VAT amount for
+      # @return [Fixnum] the VAT amount for a single unit in cents
+      def vat_amount_from_line_item line_item
+        amount = line_item.included_tax_total / line_item.quantity
+
+        Spree::Money.new(
+          BigDecimal.new(amount.to_s).round(2, BigDecimal::ROUND_HALF_UP),
+          currency: line_item.currency
+        ).cents
+      end
+
+      # Gets the VAT adjustments for the given line item
+      #
+      # @return [Array<Spree::Adjustment>] The VAT adjustment
+      def sum_of_tax_rates line_item
+        line_item.adjustments.tax.
+          joins("INNER JOIN spree_tax_rates ON spree_tax_rates.id = spree_adjustments.source_id").
+          where(spree_tax_rates: { included_in_price: true }).
+          map(&:source).
+          sum(&:amount)
+      end
+
+      def round_to_two_places(amount)
+        BigDecimal.new(amount.to_s).round(2, BigDecimal::ROUND_HALF_UP)
+      end
+    end
+  end
+end

--- a/lib/spree/adyen/payment_check.rb
+++ b/lib/spree/adyen/payment_check.rb
@@ -3,6 +3,10 @@ module Spree
     # Used when we have to override functionally inside spree, usually payments,
     # that is a conditional flow only on adyen payments.
     module PaymentCheck
+      def ratepay? payment = self
+        payment.payment_method.class == Spree::Gateway::AdyenRatepay
+      end
+
       def hpp_payment? payment = self
         payment.source.class == Spree::Adyen::HppSource
       end

--- a/spec/factories/spree_adyen_ratepay_source.rb
+++ b/spec/factories/spree_adyen_ratepay_source.rb
@@ -2,8 +2,11 @@ FactoryGirl.define do
   factory :spree_adyen_ratepay_source, aliases: [:ratepay_source], class: "Spree::Adyen::RatepaySource" do
     auth_result "Authorised"
     psp_reference { SecureRandom.hex }
-    dob_day "12"
-    dob_month "12"
-    dob_year "1970"
+
+    trait :dob_provided do
+      dob_day "12"
+      dob_month "12"
+      dob_year "1970"
+    end
   end
 end

--- a/spec/factories/spree_adyen_ratepay_source.rb
+++ b/spec/factories/spree_adyen_ratepay_source.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :spree_adyen_ratepay_source, aliases: [:ratepay_source], class: "Spree::Adyen::RatepaySource" do
+    auth_result "Authorised"
+    psp_reference { SecureRandom.hex }
+    dob_day "12"
+    dob_month "12"
+    dob_year "1970"
+  end
+end

--- a/spec/factories/spree_gateway_adyen_ratepay.rb
+++ b/spec/factories/spree_gateway_adyen_ratepay.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :spree_gateway_adyen_ratepay, aliases: [:ratepay_gateway],
+    class: "Spree::Gateway::AdyenRatepay" do
+    name "Ratepay"
+    display_on "both"
+
+    trait :env_configured do
+      preferred_api_password { ENV.fetch("ADYEN_API_PASSWORD") }
+      preferred_api_username { ENV.fetch("ADYEN_API_USERNAME") }
+    end
+  end
+end

--- a/spec/factories/spree_payment.rb
+++ b/spec/factories/spree_payment.rb
@@ -12,6 +12,11 @@ FactoryGirl.define do
     end
   end
 
+  factory :ratepay_payment, parent: :payment do
+    association :payment_method, factory: :ratepay_gateway
+    association :source, factory: :ratepay_source
+  end
+
   factory :adyen_cc_payment, parent: :payment do
     association :payment_method, factory: :spree_gateway_adyen_credit_card
     association :source, factory: :credit_card

--- a/spec/lib/spree/adyen/client_spec.rb
+++ b/spec/lib/spree/adyen/client_spec.rb
@@ -64,6 +64,11 @@ describe Spree::Adyen::Client do
     end
   end
 
+  describe "#authorise_payment" do
+    include_examples "client API request",
+      :authorise_payment, :authorise_payment
+  end
+
   describe "#authorise_recurring_payment" do
     include_examples "client API request",
       :authorise_recurring_payment, :authorise_recurring_payment

--- a/spec/lib/spree/adyen/hpp/params_spec.rb
+++ b/spec/lib/spree/adyen/hpp/params_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe Spree::Adyen::HPP::Params do
+  let(:payment_method) { build_stubbed :ratepay_gateway }
+  let(:country) { build_stubbed :country }
+  let(:address) do
+    build_stubbed :address,
+      address1: "42 Spruce Lane",
+      city: "Gotham",
+      zipcode: "90210",
+      country: country,
+      firstname: "Wade",
+      lastname: "Wilson",
+      phone: "1234567890"
+  end
+  let(:order) do
+    build_stubbed :order,
+      number: "R9999999",
+      user_id: 42,
+      total: 2000,
+      email: "batman@example.com",
+      last_ip_address: "10.1.1.1",
+      ship_address: address,
+      bill_address: address
+  end
+
+  describe "#authorise_invoice" do
+    subject { described_class.new(order, payment_method).authorise_invoice("1986-06-06") }
+
+    it "returns the correct params" do
+      expect(subject).to include({
+        merchant_account: "fake_api_merchant_account",
+        reference: "R9999999",
+        amount: {
+          currency: "USD",
+          value: 200000
+        },
+        shopper_email: "batman@example.com",
+        shopper_reference: "42",
+        shopper_name: {
+          first_name: "Wade",
+          infix: "",
+          last_name: "Wilson",
+          gender: "UNKNOWN"
+        },
+        shopper_i_p: "10.1.1.1",
+        shopper_country: "US",
+        date_of_birth: "1986-06-06",
+        telephone_number: "1234567890",
+        delivery_address: {
+          street: "Spruce Lane",
+          house_number_or_name: "42",
+          city: "Gotham",
+          postal_code: "90210",
+          country: "US",
+        },
+        billing_address: {
+          street: "Spruce Lane",
+          house_number_or_name: "42",
+          city: "Gotham",
+          postal_code: "90210",
+          country: "US",
+        },
+        additional_data: {
+          openinvoicedata: anything # Tested in Spree::Adyen::Invoice spec
+        }
+      })
+    end
+  end
+end

--- a/spec/lib/spree/adyen/hpp_spec.rb
+++ b/spec/lib/spree/adyen/hpp_spec.rb
@@ -58,6 +58,42 @@ RSpec.describe Spree::Adyen::HPP do
           to include({ foo: "bar" })
       end
     end
+
+    context "when no custom invoice class is specified" do
+      it "uses the default class" do
+        expect(subject.invoice_class).to eq Spree::Adyen::Invoice
+      end
+    end
+
+    context "when a custom invoice class is provided" do
+      before do
+        class InvoiceOverride < Spree::Adyen::Invoice
+          def request_params
+            { peter: "parker" }
+          end
+        end
+
+        Spree::Adyen::HPP.configure do |config|
+          config.invoice_class = InvoiceOverride
+        end
+      end
+
+      # Reset the configuration for other tests
+      after do
+        Spree::Adyen::HPP.configure do |config|
+          config.params_class = Spree::Adyen::HPP::Params
+        end
+      end
+
+      it "uses the custom class" do
+        expect(subject.invoice_class).to eq InvoiceOverride
+      end
+
+      it "returns the correct params" do
+        invoice = subject.invoice_class.new(order)
+        expect(invoice.request_params).to include({ peter: "parker" })
+      end
+    end
   end
 
   describe "directory_url" do

--- a/spec/lib/spree/adyen/invoice_spec.rb
+++ b/spec/lib/spree/adyen/invoice_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe Spree::Adyen::Invoice do
+  describe "#request_params" do
+    let(:address) { create(:address) }
+    let(:tax_rate_country) { address.country }
+    let(:tax_category) { create(:tax_category) }
+    let!(:zone) { create(:zone, name: "Country Zone", default_tax: true, countries: [tax_rate_country]) }
+    let!(:rate) { create(:tax_rate, tax_category: tax_category, amount: 0.19, included_in_price: true, zone: zone) }
+    let(:order) do
+      create(
+        :order_with_line_items,
+        number: "R9999999",
+        line_items_attributes: [
+          { price: 70, quantity: quantity, tax_category: tax_category }
+        ],
+        ship_address: address
+      )
+    end
+
+    describe "#request_params" do
+      subject { described_class.new(order).request_params }
+      let(:quantity) { 1 }
+
+      it "generates the correct params" do
+        expect(subject).to include(
+          openinvoicedata: {
+            number_of_lines: 1,
+            refund_description: "Refund for R9999999",
+            "line1" => {
+              currency_code: "USD",
+              description: anything,
+              item_amount: 5882,
+              item_vat_amount: 1118,
+              item_vat_percentage: 1900,
+              line_reference: 1,
+              number_of_items: 1,
+              vat_category: "High"
+            }
+          }
+        )
+      end
+
+      context "line item has quantity 1" do
+        it "has the correct item and VAT amount" do
+          invoice_line = subject[:openinvoicedata]["line1"]
+          expect(invoice_line[:item_amount]).to eq 5882
+          expect(invoice_line[:item_vat_amount]).to eq 1118
+        end
+      end
+
+      # Before fixing rounding errors, a quantity of 2 would produce an item VAT
+      # amount of 1117, making the item total 6999 instead of 7000
+      context "line item has quantity 2" do
+        let(:quantity) { 2 }
+
+        it "has the correct item and VAT amount" do
+          invoice_line = subject[:openinvoicedata]["line1"]
+          expect(invoice_line[:item_amount]).to eq 5882
+          expect(invoice_line[:item_vat_amount]).to eq 1118
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/requests/notification_processing_spec.rb
+++ b/spec/lib/tasks/requests/notification_processing_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe "Notification processing", type: :request do
     ENV["ADYEN_NOTIFY_USER"] = "spree_user"
     ENV["ADYEN_NOTIFY_PASSWD"] = "1234"
 
-    order.contents.advance
-    expect(order.state).to eq "payment"
+    # push the order through to payment
+    while order.state != "payment"
+      order.next!
+    end
   end
 
-  let!(:order) { create(:order_with_line_items, number: "R207199925") }
+  let!(:order) { create :order_with_line_items, number: "R207199925" }
 
   let!(:payment_method) do
     create(

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -3,13 +3,10 @@ require "spec_helper"
 RSpec.describe Spree::Adyen::NotificationProcessor do
   include_context "mock adyen client", success: true
 
-  let!(:order) do
-    # spree factories suck, it's not easy to get something to payment state
-    create(:order_with_line_items).tap do |order|
-      order.contents.advance
-      expect(order.state).to eq "payment"
-    end
-  end
+  let!(:order) { create :order_with_line_items }
+
+  # Push the order through to payment
+  before { while order.state != "payment"; order.next!; end }
 
   describe "#process" do
     subject { described_class.new(notification).process! }

--- a/spec/models/spree/adyen/ratepay_source_spec.rb
+++ b/spec/models/spree/adyen/ratepay_source_spec.rb
@@ -13,4 +13,16 @@ describe Spree::Adyen::RatepaySource do
       expect(subject.date_of_birth).to eq "1983-01-02"
     end
   end
+
+  describe "#has_dob?" do
+    context "when the date of birth is set" do
+      subject { build_stubbed(:ratepay_source, :dob_provided).has_dob? }
+      it { is_expected.to be true }
+    end
+
+    context "when no date of birth is set" do
+      subject { build_stubbed(:ratepay_source).has_dob? }
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/spree/adyen/ratepay_source_spec.rb
+++ b/spec/models/spree/adyen/ratepay_source_spec.rb
@@ -5,4 +5,12 @@ describe Spree::Adyen::RatepaySource do
   it { is_expected.to belong_to(:user) }
   it { is_expected.to have_one(:payment) }
   it { is_expected.to have_many(:notifications) }
+
+  subject { build_stubbed :ratepay_source, dob_day: "01", dob_month: "02", dob_year: "1983" }
+
+  describe "#date_of_birth" do
+    it "returns the formatted date of birth" do
+      expect(subject.date_of_birth).to eq "1983-01-02"
+    end
+  end
 end

--- a/spec/models/spree/adyen/ratepay_source_spec.rb
+++ b/spec/models/spree/adyen/ratepay_source_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe Spree::Adyen::RatepaySource do
+  it { is_expected.to belong_to(:payment_method) }
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to have_one(:payment) }
+  it { is_expected.to have_many(:notifications) }
+end

--- a/spec/models/spree/gateway/adyen_ratepay_spec.rb
+++ b/spec/models/spree/gateway/adyen_ratepay_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Spree::Gateway::AdyenRatepay do
+  let(:ratepay) { build_stubbed :ratepay_gateway }
+
+  describe "#method_type" do
+    it "is always 'adyen_ratepay'" do
+      expect(ratepay.method_type).to eq "adyen_ratepay"
+    end
+  end
+
+  describe "#payment_source_class" do
+    it "uses the Ratepay source" do
+      expect(ratepay.payment_source_class).to eq Spree::Adyen::RatepaySource
+    end
+  end
+
+  describe "#authorize" do
+    subject { ratepay.authorize(200, nil, {}) }
+
+    it "returns a mock successful ActiveMerchant::Billing response" do
+      expect(subject).to be_a ActiveMerchant::Billing::Response
+      expect(subject.success?).to be true
+    end
+  end
+end

--- a/spec/support/shared_contexts/mock_adyen_client.rb
+++ b/spec/support/shared_contexts/mock_adyen_client.rb
@@ -18,7 +18,7 @@ shared_context "mock adyen client" do |success:, fault_message: "", psp_referenc
     ])
   end
   let(:successful_gateway_response) do
-    double("Gateway Response", success?: true)
+    double("Gateway Response", success?: true, result_code: "Authorised")
   end
 
   let(:client) do
@@ -34,6 +34,20 @@ shared_context "mock adyen client" do |success:, fault_message: "", psp_referenc
     end
 
     instance_double("Spree::Adyen::Client").tap do |double|
+      allow(double).
+        to receive(:authorise_payment).
+        with(
+          hash_including(
+            :reference,
+            :merchant_account,
+            :amount,
+            :billing_address,
+            :shopper_i_p,
+            :shopper_email,
+            :shopper_reference,
+          ),
+      ).and_return(api_response.call(successful_gateway_response))
+
       allow(double).
         to receive(:authorise_recurring_payment).
         with(


### PR DESCRIPTION
Adyen just released an API integration for Ratepay invoice payments. This provides a much better experience for users because we no longer have to redirect the user off-site to the HPP page. This PR allows us to add Ratepay as a payment method and process invoice payments directly through the regular checkout flow.

Added in this PR:
- Ratepay payment method
- Ratepay payment source
- Basic view used in the `payment` checkout step
- Processing logic for Ratepay payments

Ratepay is currently only supported for specific European countries (DE, AT, CH, NL), each of which has a corresponding payment method in Adyen's admin. To select which one to use, Adyen requires us to pass in a `selectedBrand` parameter, where all the brands are formatted as "ratepay_<country_code>" (ie: ratepay_DE). This parameter is generated using the country ISO from the billing address, so the payment will be rejected if the billing address is not in one of these countries.

To process Ratepay payments, we are required to provide the user's date of birth. In order to avoid persisting user's DOB, I set the DOB fields as attr_accessors on the payment source, similar to how we set encrypted credit card data. This means we only have access to it in the `payment` checkout step, which is why the payment authorization is done in an `after_create` callback.

**NOTE**: This means that if the user goes back to the payment step during checkout and uses a different payment method, there will be an open authorization for Ratepay. This needs to be cancelled either manually or programatically.
