### PR TITLE
Return nil for psp_reference for server errors

### DIFF
--- a/lib/spree/adyen/api_response.rb
+++ b/lib/spree/adyen/api_response.rb
@@ -12,6 +12,7 @@ module Spree
       end
 
       def psp_reference
+        return nil if error_response?
         @gateway_response[:psp_reference]
       end
 


### PR DESCRIPTION
This would cause an error otherwise because Adyen::REST::ResponseError does not have an `[]` method.
