### PR TITLE
Update before_filter -> before_action for Rails 5

### DIFF
--- a/app/controllers/concerns/spree/adyen/admin/refunds_controller.rb
+++ b/app/controllers/concerns/spree/adyen/admin/refunds_controller.rb
@@ -6,7 +6,7 @@ module Spree
         include Spree::Adyen::PaymentCheck
 
         included do
-          before_filter :adyen_create, only: [:create]
+          before_action :adyen_create, only: [:create]
         end
 
         def adyen_create

--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -1,8 +1,8 @@
 module Spree
   class AdyenNotificationsController < AdyenController
-    skip_before_filter :verify_authenticity_token
+    skip_before_action :verify_authenticity_token
 
-    before_filter :authenticate
+    before_action :authenticate
 
     def notify
       if notification_exists?(params)

--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -1,9 +1,9 @@
 module Spree
   class AdyenRedirectController < AdyenController
-    before_filter :restore_session
-    before_filter :check_signature, only: :confirm
+    before_action :restore_session
+    before_action :check_signature, only: :confirm
 
-    skip_before_filter :verify_authenticity_token
+    skip_before_action :verify_authenticity_token
 
     # This is the entry point after an Adyen HPP payment is completed
     def confirm


### PR DESCRIPTION
Avoid deprecation warnings like:

> before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead