### PR TITLE
Remove display_on attribute from factories

### DIFF
--- a/spec/factories/spree_gateway_adyen_hpp.rb
+++ b/spec/factories/spree_gateway_adyen_hpp.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :spree_gateway_adyen_hpp, aliases: [:hpp_gateway],
     class: "Spree::Gateway::AdyenHPP" do
     name "Adyen"
-    display_on "both"
     preferences(
       skin_code: "XXXXX",
       shared_secret: "1234",

--- a/spec/factories/spree_gateway_adyen_ratepay.rb
+++ b/spec/factories/spree_gateway_adyen_ratepay.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :spree_gateway_adyen_ratepay, aliases: [:ratepay_gateway],
     class: "Spree::Gateway::AdyenRatepay" do
     name "Ratepay"
-    display_on "both"
 
     trait :env_configured do
       preferred_api_password { ENV.fetch("ADYEN_API_PASSWORD") }


### PR DESCRIPTION
In Solidus 2.x this is deprecated and should use `available_to_users` and `available_to_admin` instead. We don't actually need to provide it in the factory and it will cause deprecation warnings for any one using these on latest Solidus.