### PR TITLE
Allow users to provide a merchant account per store

### DIFF
--- a/app/models/concerns/spree/gateway/adyen_gateway.rb
+++ b/app/models/concerns/spree/gateway/adyen_gateway.rb
@@ -6,6 +6,7 @@ module Spree
       preference :api_password, :string
       preference :api_username, :string
       preference :merchant_account, :string
+      preference :store_merchant_account_map, :hash, default: {}
     end
 
     def api_password
@@ -20,6 +21,13 @@ module Spree
       ENV["ADYEN_MERCHANT_ACCOUNT"] || preferred_merchant_account
     end
 
+    def account_locator
+      SolidusAdyen::AccountLocator.new(
+        preferred_store_merchant_account_map,
+        merchant_account
+      )
+    end
+
     def provider_class
       ::Adyen::REST
     end
@@ -32,7 +40,7 @@ module Spree
 
     def cancel(psp_reference, _gateway_options = {})
       params = {
-        merchant_account: merchant_account,
+        merchant_account: account_locator.by_reference(psp_reference),
         original_reference: psp_reference
       }
 
@@ -66,7 +74,7 @@ module Spree
 
     def modification_request(amount, currency, psp_reference)
       {
-        merchant_account: merchant_account,
+        merchant_account: account_locator.by_reference(psp_reference),
         modification_amount: { currency: currency, value: amount },
         original_reference: psp_reference,
       }

--- a/lib/solidus_adyen/account_locator.rb
+++ b/lib/solidus_adyen/account_locator.rb
@@ -1,0 +1,56 @@
+# Users may want to have transactions for different stores be processed by
+# different merchant accounts in Adyen. We don't always have direct access to
+# the store when creating a payment request, so this class provides methods to
+# look up the store and its corresponding merchant account given limited information.
+#
+# For example:
+# In gateway actions such as authorize, capture, cancel, etc. the
+# only information we consistently have access to is the psp reference for the
+# payment.
+module SolidusAdyen
+  class AccountLocator
+    attr_reader :store_account_map, :default_account
+    # Creates a new merchant account locator.
+    #
+    # @param store_account_map [Hash] a hash mapping store codes to merchant accounts
+    # @param default_account [String] the default merchant account to use
+    def initialize(store_account_map, default_account)
+      @store_account_map = store_account_map
+      @default_account = default_account
+    end
+
+    # Tries to find a store that has a payment with the given psp reference. If
+    # one exists, returns the merchant account for that store. Otherwise, returns
+    # the default merchant acount.
+    #
+    # @param psp_reference [String] the psp reference for the payment
+    # @return merchant account [String] the name of the merchant account
+    def by_reference(psp_reference)
+      code = Spree::Store.
+        joins(orders: :payments).
+        find_by(spree_payments: { response_code: psp_reference }).
+        try!(:code)
+
+      by_store_code(code)
+    end
+
+    # If the order belongs to a store, returns the merchant account for that
+    # store. Otherwise, returns the default merchant account.
+    #
+    # @param order [Spree::Order] the order used to find the merchant account
+    # @return merchant account [String] the name of the merchant account
+    def by_order(order)
+      code = order.store.try!(:code)
+      by_store_code(code)
+    end
+
+    # Returns the merchant account for the store if one is provided. Returns
+    # the default merchant account otherwise.
+    #
+    # @param code [String] the store code used to look up the merchant account
+    # @return merchant account [String] the name of the merchant account
+    def by_store_code(code)
+      store_account_map[code] || default_account
+    end
+  end
+end

--- a/lib/spree/adyen/hpp/params.rb
+++ b/lib/spree/adyen/hpp/params.rb
@@ -36,7 +36,7 @@ module Spree
 
         def authorisation_request
           {
-            merchant_account: @payment_method.merchant_account,
+            merchant_account: @payment_method.account_locator.by_order(@order),
             reference: @order.number,
             amount: {
               currency: @order.currency,
@@ -60,7 +60,7 @@ module Spree
         end
 
         def payment_method_params
-          { merchant_account: @payment_method.merchant_account,
+          { merchant_account: @payment_method.account_locator.by_order(@order),
             skin_code: @payment_method.skin_code,
             shared_secret: @payment_method.shared_secret,
             ship_before_date: @payment_method.ship_before_date

--- a/spec/lib/solidus_adyen/account_locator_spec.rb
+++ b/spec/lib/solidus_adyen/account_locator_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe SolidusAdyen::AccountLocator do
+  let(:account_locator) { described_class.new({ "test" => "OTHER_ACCOUNT" }, "DEFAULT_ACCOUNT") }
+
+  describe "#by_reference" do
+    let(:store) { create(:store, code: "test") }
+    let(:order) { build(:order, store: store) }
+    let!(:payment) { create(:payment, order: order, response_code: "AUTH") }
+
+    subject { account_locator.by_reference("AUTH") }
+    # Solidus 1.3+ requires orders to belong to a store, so I need to skip
+    # validations to test this behaviour
+    before { order.save(validate: false) }
+
+    context "the payment's order belongs to a store" do
+      it { is_expected.to eq "OTHER_ACCOUNT" }
+    end
+
+    context "the payment's order does not belong to a store" do
+      let(:store) { nil }
+      it { is_expected.to eq "DEFAULT_ACCOUNT" }
+    end
+  end
+
+  describe "#by_order" do
+    let(:store) { build_stubbed(:store, code: "test") }
+    let(:order) { build_stubbed(:order, store: store) }
+
+    subject { account_locator.by_order(order) }
+
+    context "order belongs to a store" do
+      it { is_expected.to eq "OTHER_ACCOUNT" }
+    end
+
+    context "order does not belong to a store" do
+      let(:store) { nil }
+      it { is_expected.to eq "DEFAULT_ACCOUNT" }
+    end
+  end
+
+  describe "#by_store_code" do
+    subject { account_locator.by_store_code(code) }
+
+    context "other merchant account set for the store" do
+      let(:code) { "test" }
+      it { is_expected.to eq "OTHER_ACCOUNT" }
+    end
+
+    context "no account set for the store" do
+      let(:code) { nil }
+      it { is_expected.to eq "DEFAULT_ACCOUNT" }
+    end
+  end
+end


### PR DESCRIPTION
It's possible that users may want transactions for different stores to be processed by different merchant accounts in Adyen. A typical use case would be that the user has stores for different countries and they have different bank accounts for each country, which are linked to different merchant accounts in Adyen.

Unfortunately we don't have easy access to the store from inside our gateway actions. The only thing they all share is the `psp_reference` which is recorded on the payment in the `response_code` field. In the case of `cancel`, this is the only parameter it receives, so looking up the store using the response code was the only way I could think to make this work for all actions.