### PR TITLE
Prefer a store specific payment method if it exists

### DIFF
--- a/app/models/spree/adyen/notification_processor.rb
+++ b/app/models/spree/adyen/notification_processor.rb
@@ -132,7 +132,7 @@ module Spree
           amount: notification.money.dollars,
           # We have no idea what payment method they used, this will be
           # updated when/if they get redirected
-          payment_method: Spree::Gateway::AdyenHPP.last,
+          payment_method: payment_method_for(order),
           response_code: notification.psp_reference,
           source: source,
           order: order
@@ -141,6 +141,12 @@ module Spree
         order.contents.advance
         order.complete
         payment
+      end
+
+      def payment_method_for(order)
+        order.store.payment_methods.where(type: 'Spree::Gateway::AdyenHPP', active: true).last!
+      rescue
+        Spree::Gateway::AdyenHPP.last
       end
 
       def should_create_payment?

--- a/spec/models/spree/adyen/notification_processor_spec.rb
+++ b/spec/models/spree/adyen/notification_processor_spec.rb
@@ -152,10 +152,33 @@ RSpec.describe Spree::Adyen::NotificationProcessor do
             create(:notification, :auth, order: order)
           end
 
-          it "creates a payment" do
-            expect { subject }.
-              to change { order.payments.count }.
-              to 1
+          context "creates a payment" do
+            it do
+              expect { subject }.
+                to change { order.payments.count }.
+                to 1
+            end
+
+            it "is store specific" do
+              store_specific_payment_method = create(:spree_gateway_adyen_hpp)
+
+              order.store.payment_methods << store_specific_payment_method
+
+              _other_payment_method = create(:spree_gateway_adyen_hpp)
+
+              expect(
+                subject.order.payments.last.payment_method
+              ).to eq(store_specific_payment_method)
+            end
+
+            it "is default" do
+              other_payment_method = create(:spree_gateway_adyen_hpp)
+
+              expect(
+                subject.order.payments.last.payment_method
+              ).to eq(other_payment_method)
+            end
+
           end
 
           it "completes the order" do


### PR DESCRIPTION
In a multi store environment it is desirable to use the store specific payment method.
If one is not defined, default back to the last Adyen payment method it can find.