### PR TITLE
3d Secure support

### DIFF
--- a/app/models/concerns/spree/adyen/payment.rb
+++ b/app/models/concerns/spree/adyen/payment.rb
@@ -11,6 +11,8 @@ module Spree
       included do
         after_create :authorise_on_create, if: :should_authorise?
 
+        attr_accessor :adyen_api_response
+
         private
 
         def authorise_on_create

--- a/app/models/spree/gateway/adyen_credit_card.rb
+++ b/app/models/spree/gateway/adyen_credit_card.rb
@@ -36,7 +36,7 @@ module Spree
       ActiveMerchant::Billing::Response.new(true, "dummy authorization response")
     end
 
-    def perform_authorization_3d(payment, adyen_3d_params)
+    def authorise_3d_secure_payment(payment, adyen_3d_params)
       response = rest_client.authorise_payment_3dsecure(authorization_request(payment, false, adyen_3d_params))
       handle_adyen_response(payment, response)
     end

--- a/app/models/spree/gateway/adyen_credit_card.rb
+++ b/app/models/spree/gateway/adyen_credit_card.rb
@@ -117,6 +117,10 @@ module Spree
         shopper_email: payment.order.email,
         shopper_reference: reference_number_from_order(payment.order),
         billing_address: billing_address_from_payment(payment),
+        browser_info: {
+          user_agent: payment.request_env["HTTP_USER_AGENT"],
+          accept_header: payment.request_env["HTTP_ACCEPT"]
+        }
       }
       request.merge!(encrypted_card_data(payment.source)) if new_card
 

--- a/lib/spree/adyen/api_response.rb
+++ b/lib/spree/adyen/api_response.rb
@@ -11,6 +11,11 @@ module Spree
         !error_response? && gateway_response.success?
       end
 
+      def redirect?
+        @gateway_response.is_a?(::Adyen::REST::AuthorisePayment::Response) &&
+          @gateway_response.attributes["paymentResult.resultCode"] == "RedirectShopper"
+      end
+
       def psp_reference
         return nil if error_response?
         @gateway_response[:psp_reference]

--- a/lib/spree/adyen/client.rb
+++ b/lib/spree/adyen/client.rb
@@ -9,6 +9,10 @@ module Spree
         execute_request(:authorise_payment, params)
       end
 
+      def authorise_payment_3dsecure params
+        execute_request(:authorise_payment_3dsecure, params)
+      end
+
       def authorise_recurring_payment params
         execute_request(:authorise_recurring_payment, params)
       end

--- a/spec/lib/spree/adyen/api_response_spec.rb
+++ b/spec/lib/spree/adyen/api_response_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "uri"
 
 describe Spree::Adyen::ApiResponse do
   let(:http_success) do
@@ -7,10 +8,23 @@ describe Spree::Adyen::ApiResponse do
       body: "resultCode=Authorised&pspReference=1234567890",
     )
   end
+  let(:http_redirect) do
+    instance_double(
+      "Net::HTTPSuccess",
+      body: URI.encode_www_form({"resultCode"=>["RedirectShopper"],
+                                 "md"=>["encryptedmd"],
+                                 "paRequest"=>["encryptedpaReq"],
+                                 "issuerUrl"=>
+                                 ["https://test.adyen.com/hpp/3d/validate.shtml"],
+                                 "pspReference"=>["1234567890"]})
+    )
+  end
   let(:http_failure) do
     instance_double(
       "Net::HTTPSuccess",
-      body: "resultCode=Refused&refusalReason=Denied&response=Modify failure",
+      body: URI.encode_www_form({"resultCode"=>["Refused"],
+                                 "refusalReason"=>["Denied"],
+                                 "response"=>["Modify failure"]})
     )
   end
   let(:http_error) do
@@ -19,6 +33,7 @@ describe Spree::Adyen::ApiResponse do
       body: "Something went wrong"
     )
   end
+  let(:api_redirect) { Adyen::REST::Response.new(http_redirect) }
   let(:api_success) { Adyen::REST::AuthorisePayment::Response.new(http_success) }
   let(:api_failure) { Adyen::REST::Response.new(http_failure) }
   let(:api_error) { Adyen::REST::ResponseError.new("ERROR") }
@@ -56,6 +71,17 @@ describe Spree::Adyen::ApiResponse do
       it "returns the response attributes" do
         expect(described_class.new(api_success).attributes).
           to eq ({ "resultCode" => "Authorised", "pspReference" =>"1234567890" })
+      end
+    end
+
+    context "when the request returns a redirect" do
+      it "returns the redirect attributes" do
+        expect(described_class.new(api_redirect).attributes).
+          to eq ({ "resultCode" => "RedirectShopper",
+                   "md" => "encryptedmd",
+                   "paRequest" => "encryptedpaReq",
+                   "pspReference" => "1234567890",
+                   "issuerUrl" => "https://test.adyen.com/hpp/3d/validate.shtml" })
       end
     end
   end

--- a/spec/support/shared_contexts/mock_adyen_client.rb
+++ b/spec/support/shared_contexts/mock_adyen_client.rb
@@ -1,4 +1,4 @@
-shared_context "mock adyen client" do |success:, fault_message: "", psp_reference: "" |
+shared_context "mock adyen client" do |success:, redirect: false, fault_message: "", psp_reference: "" |
   before do
     allow(Spree::Adyen::Client).
       to receive(:new).
@@ -26,6 +26,7 @@ shared_context "mock adyen client" do |success:, fault_message: "", psp_referenc
       instance_double(
         "Spree::Adyen::ApiResponse",
         success?: success,
+        redirect?: redirect,
         message: fault_message,
         psp_reference: psp_reference,
         attributes: { "resultCode" => "Authorised" },


### PR DESCRIPTION
This PR adds support for 3d Secure payments.

[Adyen Documentation](https://docs.adyen.com/developers/api-manual#3dsecure)

- `browser_info` is included in authorization requests when `payment.request_env` is available. This is required for 3d secure.
- `authorise_new_payment` flow has been adjusted to account for `redirectShopper` responses from adyen. This is the form of response if 3d Secure is enabled on the Adyen account and the card submitted for authorization is enrolled in 3d Secure.
- An `adyen_api_response` instance variable is utilized on `Spree::Payment` to make the response available to the controller so it can be passed to the frontend.
- An `authorise3d` endpoint has been added and is expected to receive the customer back after 3D Secure verification. This endpoint should be specified, with the `payment.number` as the `payment_reference` query parameter, as `TermUrl` in the redirect form.

An implementation of Adyen 3d secure should use the contents of `adyen_api_response`, the `adyen_authorise3d_url` endpoint, and the `payment.number` to build a form that is then submitted to redirect the customer to the card issuer for 3D Secure verification. The `TermUrl` field of the form should include the `payment.number` as a query parameter: `payment_reference`.