### PR TITLE
Update extension to work with modern versions of Solidus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ env:
   - DB=postgres
 install:
   - bundle install
+env:
+  matrix:
+    - SOLIDUS_BRANCH=v1.3
+    - SOLIDUS_BRANCH=v1.4
+    - SOLIDUS_BRANCH=v2.0
+    - SOLIDUS_BRANCH=v2.1
+    - SOLIDUS_BRANCH=v2.2
+    - SOLIDUS_BRANCH=master
 script:
   - bundle exec rake test_app
   - ( cd ./spec/dummy && bundle exec rake solidus-adyen:factory_girl:lint RAILS_ENV=test )

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
     - SOLIDUS_BRANCH=v2.0
     - SOLIDUS_BRANCH=v2.1
     - SOLIDUS_BRANCH=v2.2
-    - SOLIDUS_BRANCH=master
 script:
   - bundle exec rake test_app
   - ( cd ./spec/dummy && bundle exec rake solidus-adyen:factory_girl:lint RAILS_ENV=test )

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 branch = ENV.fetch("SOLIDUS_BRANCH", "master")
+
 if branch == "master" || branch >= "v2.0"
   gem "rails-controller-testing", group: :test
 end
@@ -11,6 +12,7 @@ elsif branch >= "v2.0"
   gem 'rails', '~> 5.0.0' # HACK: broken bundler dependency resolution
 else
   gem "rails", '~> 4.2.0' # HACK: broken bundler dependency resolution
+  gem 'rails_test_params_backport', group: :test
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,17 @@ if branch == "master" || branch >= "v2.0"
   gem "rails-controller-testing", group: :test
 end
 
+if branch == 'master' || branch >= "v2.3"
+  gem 'rails', '~> 5.1.0' # HACK: broken bundler dependency resolution
+elsif branch >= "v2.0"
+  gem 'rails', '~> 5.0.0' # HACK: broken bundler dependency resolution
+else
+  gem "rails", '~> 4.2.0' # HACK: broken bundler dependency resolution
+end
+
 group :development, :test do
   gem "solidus", github: 'solidusio/solidus', branch: branch
   gem "solidus_auth_devise"
-
 
   gem "pg"
   gem "mysql2"

--- a/app/assets/stylesheets/spree/backend/solidus-adyen.css
+++ b/app/assets/stylesheets/spree/backend/solidus-adyen.css
@@ -1,5 +1,0 @@
-/*
- *= require spree/backend
- *= require spree/backend/solidus-adyen/buttons
- *= require spree/backend/solidus-adyen/communication
- */

--- a/app/assets/stylesheets/spree/backend/solidus-adyen.scss
+++ b/app/assets/stylesheets/spree/backend/solidus-adyen.scss
@@ -1,0 +1,6 @@
+@import "spree/backend/spree_admin";
+
+@import "spree/backend/solidus-adyen/variables";
+
+@import "spree/backend/solidus-adyen/buttons";
+@import "spree/backend/solidus-adyen/communication";

--- a/app/assets/stylesheets/spree/backend/solidus-adyen/buttons.scss
+++ b/app/assets/stylesheets/spree/backend/solidus-adyen/buttons.scss
@@ -1,5 +1,3 @@
-@import 'variables';
-
 .button-error {
   background-color: $color-error;
 

--- a/app/assets/stylesheets/spree/backend/solidus-adyen/communication.scss
+++ b/app/assets/stylesheets/spree/backend/solidus-adyen/communication.scss
@@ -1,6 +1,3 @@
-@import 'variables';
-@import 'bourbon';
-
 $color-received-bg: mix($color-3, white, 10%);
 $color-sent-bg: mix($color-3, white, 100%);
 $notch-size-side: 12px;

--- a/app/assets/stylesheets/spree/backend/solidus-adyen/variables.scss
+++ b/app/assets/stylesheets/spree/backend/solidus-adyen/variables.scss
@@ -1,4 +1,2 @@
-@import 'spree/backend/globals/variables';
-
 $color-safety-yellow: #eed202;
 $color-warning: $color-safety-yellow;

--- a/db/migrate/20131017040945_create_adyen_notifications.rb
+++ b/db/migrate/20131017040945_create_adyen_notifications.rb
@@ -1,5 +1,5 @@
 # @private
-class CreateAdyenNotifications < ActiveRecord::Migration
+class CreateAdyenNotifications < SolidusSupport::Migration[4.2]
   
   def self.up
     create_table :adyen_notifications do |t|

--- a/db/migrate/20150911201942_add_index_adyen_notifications_psp_reference.rb
+++ b/db/migrate/20150911201942_add_index_adyen_notifications_psp_reference.rb
@@ -1,4 +1,4 @@
-class AddIndexAdyenNotificationsPspReference < ActiveRecord::Migration
+class AddIndexAdyenNotificationsPspReference < SolidusSupport::Migration[4.2]
   def change
     add_index :adyen_notifications, [:psp_reference], unique: true
   end

--- a/db/migrate/20150914162539_create_spree_adyen_hpp_sources.rb
+++ b/db/migrate/20150914162539_create_spree_adyen_hpp_sources.rb
@@ -1,6 +1,6 @@
 # Fields come from
 # https://docs.adyen.com/display/TD/HPP+payment+response
-class CreateSpreeAdyenHppSources < ActiveRecord::Migration
+class CreateSpreeAdyenHppSources < SolidusSupport::Migration[4.2]
   def change
     create_table :spree_adyen_hpp_sources do |t|
       t.string :auth_result

--- a/db/migrate/20151007090519_add_days_to_ship_to_config.rb
+++ b/db/migrate/20151007090519_add_days_to_ship_to_config.rb
@@ -1,4 +1,4 @@
-class AddDaysToShipToConfig < ActiveRecord::Migration
+class AddDaysToShipToConfig < SolidusSupport::Migration[4.2]
   def change
     add_column :spree_adyen_hpp_sources, :days_to_ship, :integer
   end

--- a/db/migrate/20151020230830_remove_indices_on_adyen_notifications.rb
+++ b/db/migrate/20151020230830_remove_indices_on_adyen_notifications.rb
@@ -1,4 +1,4 @@
-class RemoveIndicesOnAdyenNotifications < ActiveRecord::Migration
+class RemoveIndicesOnAdyenNotifications < SolidusSupport::Migration[4.2]
   def change
     remove_index :adyen_notifications, name: "adyen_notification_uniqueness"
     remove_index :adyen_notifications, [:psp_reference]

--- a/db/migrate/20151106093023_allow_merchant_reference_to_be_null_for_adyen_notification.rb
+++ b/db/migrate/20151106093023_allow_merchant_reference_to_be_null_for_adyen_notification.rb
@@ -1,4 +1,4 @@
-class AllowMerchantReferenceToBeNullForAdyenNotification < ActiveRecord::Migration
+class AllowMerchantReferenceToBeNullForAdyenNotification < SolidusSupport::Migration[4.2]
   def change
     change_column :adyen_notifications, :merchant_reference, :string, null: true
   end

--- a/db/migrate/20151123000000_recreate_adyen_notification_index.rb
+++ b/db/migrate/20151123000000_recreate_adyen_notification_index.rb
@@ -1,4 +1,4 @@
-class RecreateAdyenNotificationIndex < ActiveRecord::Migration
+class RecreateAdyenNotificationIndex < SolidusSupport::Migration[4.2]
   def change
     add_index :adyen_notifications, [:psp_reference, :event_code, :success], unique: true, name: "adyen_notification_uniqueness"
   end

--- a/db/migrate/20160927175452_create_spree_adyen_ratepay_sources.rb
+++ b/db/migrate/20160927175452_create_spree_adyen_ratepay_sources.rb
@@ -1,4 +1,4 @@
-class CreateSpreeAdyenRatepaySources < ActiveRecord::Migration
+class CreateSpreeAdyenRatepaySources < SolidusSupport::Migration[4.2]
   def change
     create_table :spree_adyen_ratepay_sources do |t|
       t.string :auth_result

--- a/solidus-adyen.gemspec
+++ b/solidus-adyen.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "adyen", "~> 2.2.0"
   spec.add_runtime_dependency "solidus_core"
+  spec.add_runtime_dependency "solidus_support"
   spec.add_runtime_dependency "bourbon"
 
   spec.add_development_dependency "sass-rails"

--- a/spec/controllers/concerns/spree/adyen/admin/refunds_controller_spec.rb
+++ b/spec/controllers/concerns/spree/adyen/admin/refunds_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Spree::Admin::RefundsController do
   routes { Spree::Core::Engine.routes }
 
   describe "POST create" do
-    subject { post :create, params }
+    subject { post :create, params: params }
 
     let(:params) do
       {

--- a/spec/controllers/spree/adyen/hpps_controller_spec.rb
+++ b/spec/controllers/spree/adyen/hpps_controller_spec.rb
@@ -18,8 +18,10 @@ RSpec.describe Spree::Adyen::HppsController, type: :controller do
     context "html response" do
       subject {
         get :directory,
-        order_id: order.id,
-        payment_method_id: payment_method.id }
+        params: {
+          order_id: order.id,
+          payment_method_id: payment_method.id
+        } }
 
       it { is_expected.to have_http_status :ok }
       it { is_expected.to render_template "directory" }
@@ -28,9 +30,12 @@ RSpec.describe Spree::Adyen::HppsController, type: :controller do
     context "json response" do
       subject {
         get :directory,
-        order_id: order.id,
-        payment_method_id: payment_method.id,
-        format: :json }
+        params: {
+          order_id: order.id,
+          payment_method_id: payment_method.id,
+          format: :json
+        }
+      }
 
       it { is_expected.to have_http_status :ok }
 

--- a/spec/controllers/spree/adyen_notifications_controller_spec.rb
+++ b/spec/controllers/spree/adyen_notifications_controller_spec.rb
@@ -47,7 +47,7 @@ describe Spree::AdyenNotificationsController do
   end
 
   describe "POST notify" do
-    subject { post :notify, params }
+    subject { post :notify, params: params }
 
     shared_examples "success" do
       it "acknowledges the request" do
@@ -91,10 +91,10 @@ describe Spree::AdyenNotificationsController do
 
         it "errors and creates a notification" do
           expect {
-            expect { post(:notify, params) }.
+            expect { post(:notify, params: params) }.
             to raise_error(StateMachines::InvalidTransition)
 
-            expect(post(:notify, params)).
+            expect(post(:notify, params: params)).
               to have_http_status(:ok).
               and have_attributes(body: "[accepted]")
           }.
@@ -113,9 +113,9 @@ describe Spree::AdyenNotificationsController do
 
       it "doesn't create a notification" do
         # explict call of subject to avoid memoization
-        post :notify, params
+        post :notify, params: params
 
-        expect{ post :notify, params }.
+        expect{ post :notify, params: params }.
           to_not change{ AdyenNotification.count }
       end
     end

--- a/spec/controllers/spree/adyen_redirect_controller_spec.rb
+++ b/spec/controllers/spree/adyen_redirect_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Spree::AdyenRedirectController, type: :controller do
   end
 
   describe "GET confirm" do
-    subject(:action) { spree_get :confirm, params }
+    subject(:action) { get :confirm, params: params }
 
     let(:psp_reference) { "8813824003752247" }
     let(:payment_method) { "amex" }

--- a/spec/lib/tasks/requests/notification_processing_spec.rb
+++ b/spec/lib/tasks/requests/notification_processing_spec.rb
@@ -146,20 +146,20 @@ RSpec.describe "Notification processing", type: :request do
 
   def authorize_request
     ActiveRecord::Base.establish_connection
-    post "/adyen/notify", auth_params, headers
+    post "/adyen/notify", params: auth_params, headers: headers
     expect(response).to have_http_status :ok
     expect(response.body).to eq "[accepted]"
   end
 
   def redirect_request
     ActiveRecord::Base.establish_connection
-    response_code = get "/checkout/payment/adyen", checkout_params, headers
+    response_code = get "/checkout/payment/adyen", params: checkout_params, headers: headers
     expect(response_code).to eq 302
   end
 
   def capture_request
     expect do
-      post "/adyen/notify", capture_params, headers
+      post "/adyen/notify", params: capture_params, headers: headers
     end.
     to change { order.payments.last.reload.state }.
     from("processing").


### PR DESCRIPTION
Includes a number of small updates to ensure this extension will work with Solidus <= 2.2

Additional work will be required to get it ready for Rails 5.1/Solidus 2.3+