### PR TITLE
Add installment payment methods as auto captured

### DIFF
--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -22,7 +22,9 @@ class AdyenNotification < ActiveRecord::Base
     "directEbanking",
     "trustly",
     "giropay",
-    "bcmc"
+    "bcmc",
+    "cofinoga_3xcb",
+    "cofinoga_4xcb"
   ].freeze
 
   AUTHORISATION = "AUTHORISATION".freeze


### PR DESCRIPTION
Adyen now supports installment payments through Cetelem. The payment method identifiers returned from Adyen are `cofinoga_3xcb` and `cofinoga_4xcb` which stand for 3 x carte bancaire and 4 x carte bancaire respectively. These allow users to pay in 3 or 4 installment payments on their credit card respectively.

These payment methods do not allow us to call `capture` on them since it's handled by a third party. Unlike SOFORT, which returns a fake success if we call capture, they will return a failed response if we try with a `does not support capture` error message. Thus we need to treat them as auto captured.