### PR TITLE
Lock order before attempting to process notifications

### DIFF
--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -11,8 +11,11 @@ module Spree
         notification = AdyenNotification.build(params)
         notification.save!
 
-        # prevent alteration to associated payment while we're handling the action
-        Spree::Adyen::NotificationProcessor.new(notification).process!
+        # Only process the notification if we have an associated order.
+        # We might not in the case of test notifications, reports, etc.
+        notification.order.try!(:with_lock) do
+          Spree::Adyen::NotificationProcessor.new(notification).process!
+        end
         accept
       end
     end


### PR DESCRIPTION
The locking used to happen at the controller level, but that was changed in:
https://github.com/StemboltHQ/solidus-adyen/pull/46

I ran into an issue with this recently when running unicorn locally. In the notification processor we assign the order and payment as `notification.order` and `notification.payment` respectively. In my case this grabbed an order that was in the middle of being modified in a transaction, so I got a stale copy. This caused multiple payments to get created because the worker receiving the notification wasn't aware that a payment had already been created.

Since we don't process the notification if there is no order anyway, I think the simplest solution is to move that logic up to the controller level and lock the order before we attempt to process the notification at all.