### PR TITLE
Speed up Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - 2.2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
+cache: bundler
 rvm:
   - 2.2.3
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 language: ruby
 cache: bundler
 rvm:


### PR DESCRIPTION
This is a very tiny PR that should make some significant improvements to our build times on Travis.

Setting `sudo: false` will cause builds to run on the container infrastructure, which allows jobs to spin up way faster than legacy builds.

Each of our jobs (per Solidus version) is doing its own `bundle install` every single time right now, which is eating up a little over 3 minutes per job. Turning on bundler caching should share the bundle between jobs and bring this number down to almost 0 unless our bundle changes.