### PR TITLE
Remove hacks for Adyen::API module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :test do
   gem "vcr"
   gem "webmock", "~> 1.24"
   gem "selenium-webdriver"
+  gem 'chromedriver-helper', require: false
 end
 
 gemspec

--- a/lib/spree/adyen/engine.rb
+++ b/lib/spree/adyen/engine.rb
@@ -42,36 +42,6 @@ module Spree
       end
 
       config.to_prepare(&method(:activate).to_proc)
-      # The module eval below adds the optional billing address parameter to the
-      # authorise payment methods so that it can be included in payment requests.
-      #
-      # This should also be deleted if it gets merged into the Adyen gem.
-      config.to_prepare do
-        ::Adyen::API.module_eval do
-          def authorise_payment(reference, amount, shopper, card, enable_recurring_contract = false, fraud_offset = nil, instant_capture = false, billing_address = nil)
-            params = { :reference       => reference,
-                       :amount          => amount,
-                       :shopper         => shopper,
-                       :card            => card,
-                       :billing_address => billing_address,
-                       :recurring       => enable_recurring_contract,
-                       :fraud_offset    => fraud_offset,
-                       :instant_capture => instant_capture }
-            ::Adyen::API::PaymentService.new(params).authorise_payment
-          end
-
-          def authorise_recurring_payment(reference, amount, shopper, recurring_detail_reference = 'LATEST', fraud_offset = nil, instant_capture = false, billing_address = nil)
-            params = { :reference => reference,
-                       :amount    => amount,
-                       :shopper   => shopper,
-                       :billing_address => billing_address,
-                       :recurring_detail_reference => recurring_detail_reference,
-                       :fraud_offset => fraud_offset,
-                       :instant_capture => instant_capture }
-            ::Adyen::API::PaymentService.new(params).authorise_recurring_payment
-          end
-        end
-      end
     end
   end
 end

--- a/spec/cassettes/Credit_Card_Authorization_Process.yml
+++ b/spec/cassettes/Credit_Card_Authorization_Process.yml
@@ -2,233 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/servlet/soap/Payment
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0"?>
-                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-                  <soap:Body>
-                            <payment:authorise xmlns:payment="http://payment.services.adyen.com" xmlns:recurring="http://recurring.services.adyen.com" xmlns:common="http://common.services.adyen.com">
-                  <payment:paymentRequest>
-                    <payment:merchantAccount><ADYEN_MERCHANT_ACCOUNT></payment:merchantAccount>
-                    <payment:reference>1</payment:reference>
-                            <additionalAmount xmlns="http://payment.services.adyen.com" xsi:nil="true" />
-                <additionalData xmlns="http://payment.services.adyen.com">
-                  <entry>
-                    <key xsi:type="xsd:string">card.encrypted.json</key>
-                    <value xsi:type="xsd:string">adyenjs_0_1_17$1Gx0g+iKAQmk7mE2aeCN9gFhQal9FFnsd/dnO9ws7ZwpquZfB1OFI8dmm6ROorQYSA9SvSSPBXKT49w3XYQWmSJbuNSks+7/gxplQjzzQzZBLfjpvkClukzrJZNfUoa6OTekj7Sc0qIlOUX9L+ynet8Aeo9g5NeIilaujMZluwB4H9QJBG2AW2O8+mi/2JIi2QfsnteJuTZMyhpcKxS2byWX/kIdvuDw9h6HTfrtouIoB3uPuWwSLeUJcBWTIpjK59Pg/Mr6ECaj8yr5aiDIDeAL7FpuGFv816Oe+83HDUDzJ7NLZBFl979u1//Cl+ko6pWyWAd62kOqYmTwCjZo7Q==$UUZOOSeaFQQcMRM2WVC9hsPUbMTlUAk4r8ETrkIzb9VY+RTFLor3IKnzVa+PxeNG0jip3Xn2HQVSWlZmskLCoJPvxLeHtmX5TLfACVOsj6scYeYk4fcF1pUMjXjDRm/zLU2d1FUz6i2KmcAlLfZ3h2fsVRObYjfggVspKQWhC+vIE6KhN271O/Xms122mlJFhwk73UDp9U9Y0lbXMvDcABWiwC9uDk8hm2FtlJubW77f0oBp5k8T6rFJ7LG7swd4iS2yOQItN32gx8kih7cyYhSN/eV1Vq7z2gjBENu/4YAmIPNUvu/VmJ+9yrFv3cMKU+H17MBYLtcloQNRmp7GJX3DA6UwxZYRkxwc5dEDKzdNwP1e8B8m2G8knuknNpEZEmBvIc9VJ7m5gftLHUwXS/DQTPPVIpP5Hn1oKFJybioFA47EYGTIKVsACtjphuhooA9kK7iiz6h7zW8W9ZfDOzyLORvBNXA8CGqfqLMuFTdzz8iwdg8KAdllBqna98amAOQffZ7amY8Mpg4sIv32k/wg1R6hDToS+fXM7l44zFE2q2CTXXjByjfPj+d8UbGlaRbTpe2zvVaJxfvo/Fs/pg//tllJy6NQxU7fDZBRMk9p15tLC7IkWltUOTOSIAsMGcXheMFqQjgORYDeOHcPaSj8RCdgJrIzeFFPTLnfjndEOUluRdjMK8tvbWmQ5YtEi07qc18tsQKVt9lxeR5j7TYJ9DEml0HlQjeY6+bMaQwgiwI6OfxZf74BONNhBKfo6FHkPq9HDVRBQyGRvI5BHWGXb0mhSK4Wk6DZC8IgSVyAs6K+hEsCDXtqGa/ORjHXe2NGTgn2S4pjiwLowS90fj2rwMzC2dpl7siB8voASQ10p9w06U89B5fTu+IJECGWf1R0d6Dg8wOtZfwRJUkEo2NWYoaGKeZFIs12D1GeiBBUPBVzQo1/pwNafNBeLQvFC8GEisea0DJa5XL8a4Y6tRvsqwI0n2Z53V9WKRwToMuVoVQV2MZkh6052kLYz9tYMtRO7qx9VMpKB2FeCkELeFJtnNqpwzKkF2o/ElToi7JaDw6i24o7K69ycXsM1782MO3Cky717pAmjniKyjo26kPeiRDf39u8TBnJupVqvIk958KgVHN+1onZmsx7D+pT+z3vOUHwDM8EoblMmyXp2XkFoAbKyCCNlyLAuzSxDmzxGP/Ndqewdgrx9SWlgu2iNwwGJnn/Rt2+QTva8Qf6/btcTBTxs5KikQ8opRnI0fiIluUsNK2novY23+XShM4QxAxbWkjABEskbGE41YAGTMjgLRg5EuiOpmTCIhCbCHyWLhDVS1iGTqMYGB38Cj4VMp372HPQfne85JeuI/FWzR6IwzYy1bTFSOPuV0cWs9bnlM3IogNTsJeSfM/THIkax6ti1MKIt7w1mT8J+RVTyUZzKK9IMZCGZsrEW1sN6emdcAFfRlt2RSiEqR2gB+9nQyoZNsj5lr167zcSgJx7rsXju5EyZ7w2EvFe3qj798qKXUid1jX6UgK2693oC9bmOFJ9wS6EYycGscPDgs0HCtXjfF7hP4DnDLfKYmdalgulH88QjYcVgC5UkdmbN9uod5mqryP2vb9r6Rz5Nxhv8yvyRWBorX7g5P2d8q0/eeICSqU2uL12yK+Fc/rUu5LH/hfs3w4d6wqRpEwUoe2ENqeeA3rEmTyOWAnqTCoKTqKyfxCLl1KD0lXvsrmwJ6Z9vmLUajDs3bU9Id5MaBdmmOqiMEZQMjLGG0utDthxYBALh4Y0jLAtQkgjxXQd2onVTg8xemvtPfFxIi1tzSZ99DlFw7EeIsLLOgiklh/tQdvCQdktGv2QQaDszGPTF3N+SHOXLy1aMKOkPiEOhEa6/B5gxvseh09LuefchHiAzaMQs9QcBlgikwtwLGRF7dFiDNZcAG4zKDrERXqzH3xL8ddsgGDKRU0mufAw8of/KIJoK6nHEqoWuhFBgTHbYmtM3opCP4MhshN/xmi1jtdwm+uyeS1VnRd0riL5LVexQYpgzw4+uuSDTZmMt+3ZcuvMDpmWWJ2MMqdzoWAGN3JKp6xjOrRJye2yTUVmozib82XY3+ExC/P7py/YAnfTZyx2UukaWEXeiCueCN1VAB1NllAWjzU3t4adGe+QrTfnbSVwW9DR/yTUGF3HT/Pb15QfCv9SucJRmZa3Jju5Gg8Rvc6fVb1uQUOAZ0hn5ySjruyV6BX6Lob+wHj9v+CVRD/hjX278FQDu3x2zPAoXJxAU/adLZbL0hvTM+IP7dFzSbazAus2YyIyp2VRukxevKRWZI7SALMmYhjcS8AU4jB/kiyfZrWa9vTtVvKxDl/pj6fuz41GNXU=</value>
-                  </entry>
-                </additionalData>
-                <payment:recurring>
-                  <payment:contract>RECURRING,ONECLICK</payment:contract>
-                </payment:recurring>
-                <payment:amount>
-                  <common:currency>USD</common:currency>
-                  <common:value>0</common:value>
-                </payment:amount>
-                <payment:shopperReference>1</payment:shopperReference>
-                <payment:shopperEmail>spree@example.com</payment:shopperEmail>
-                <payment:shopperIP></payment:shopperIP>
-                <payment:shopperStatement>R285069127</payment:shopperStatement>
-                  </payment:paymentRequest>
-                </payment:authorise>
-
-                  </soap:Body>
-                </soap:Envelope>
-    headers:
-      Accept:
-      - text/xml
-      Content-Type:
-      - text/xml; charset=utf-8
-      Soapaction:
-      - authorise
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 02 May 2016 15:24:21 GMT
-      Server:
-      - Apache
-      Set-Cookie:
-      - JSESSIONID=C3D4D774BF34B8467855EF99A586B253.test103e; Path=/pal/; Secure;
-        HttpOnly
-      Last-Modified:
-      - Mon, 02 May 2016 15:24:21 GMT
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - text/xml;charset=UTF-8
-    body:
-      encoding: UTF-8
-      string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soap:Body><ns1:authoriseResponse
-        xmlns:ns1="http://payment.services.adyen.com"><ns1:paymentResult><additionalData
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><authCode xmlns="http://payment.services.adyen.com">3603</authCode><dccAmount
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><dccSignature xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /><fraudResult xmlns="http://payment.services.adyen.com" xsi:nil="true"
-        /><issuerUrl xmlns="http://payment.services.adyen.com" xsi:nil="true" /><md
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><paRequest xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /><pspReference xmlns="http://payment.services.adyen.com">8814622026610346</pspReference><refusalReason
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><resultCode xmlns="http://payment.services.adyen.com">Authorised</resultCode></ns1:paymentResult></ns1:authoriseResponse></soap:Body></soap:Envelope>
-    http_version: 
-  recorded_at: Mon, 02 May 2016 15:24:21 GMT
-- request:
-    method: post
-    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/servlet/soap/Recurring
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0"?>
-                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-                  <soap:Body>
-                        <recurring:listRecurringDetails xmlns:payment="http://payment.services.adyen.com" xmlns:recurring="http://recurring.services.adyen.com">
-              <recurring:request>
-                <recurring:recurring>
-                  <payment:contract>RECURRING</payment:contract>
-                </recurring:recurring>
-                <recurring:merchantAccount><ADYEN_MERCHANT_ACCOUNT></recurring:merchantAccount>
-                <recurring:shopperReference>1</recurring:shopperReference>
-              </recurring:request>
-            </recurring:listRecurringDetails>
-
-                  </soap:Body>
-                </soap:Envelope>
-    headers:
-      Accept:
-      - text/xml
-      Content-Type:
-      - text/xml; charset=utf-8
-      Soapaction:
-      - listRecurringDetails
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 02 May 2016 15:24:21 GMT
-      Server:
-      - Apache
-      Set-Cookie:
-      - JSESSIONID=F41BB7222421E85D15BDEAD38EE78C89.test104e; Path=/pal/; Secure;
-        HttpOnly
-      Pspreference:
-      - '7914622026617821'
-      Content-Length:
-      - '1728'
-      Content-Type:
-      - text/xml;charset=utf-8
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soap:Body><recurring:listRecurringDetailsResponse
-        xmlns:recurring="http://recurring.services.adyen.com"><recurring:result><creationDate
-        xmlns="http://recurring.services.adyen.com">2016-04-28T14:18:41+02:00</creationDate><details
-        xmlns="http://recurring.services.adyen.com"><RecurringDetail><bank xsi:nil="true"
-        /><card><billingAddress xmlns="http://payment.services.adyen.com" xsi:nil="true"
-        /><brand xmlns="http://payment.services.adyen.com" xsi:nil="true" /><cvc xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /><expiryMonth xmlns="http://payment.services.adyen.com">6</expiryMonth><expiryYear
-        xmlns="http://payment.services.adyen.com">2016</expiryYear><holderName xmlns="http://payment.services.adyen.com">John
-        Doe</holderName><issueNumber xmlns="http://payment.services.adyen.com" xsi:nil="true"
-        /><number xmlns="http://payment.services.adyen.com">1111</number><startMonth
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><startYear xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /></card><creationDate>2016-04-28T14:18:41+02:00</creationDate><elv
-        xsi:nil="true" /><name xsi:nil="true" /><recurringDetailReference>8414618459219534</recurringDetailReference><variant>visa</variant></RecurringDetail></details><lastKnownShopperEmail
-        xmlns="http://recurring.services.adyen.com">spree@example.com</lastKnownShopperEmail><shopperReference
-        xmlns="http://recurring.services.adyen.com">1</shopperReference></recurring:result></recurring:listRecurringDetailsResponse></soap:Body></soap:Envelope>
-    http_version: 
-  recorded_at: Mon, 02 May 2016 15:24:21 GMT
-- request:
-    method: post
-    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/servlet/soap/Payment
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0"?>
-                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-                  <soap:Body>
-                            <payment:authorise xmlns:payment="http://payment.services.adyen.com" xmlns:recurring="http://recurring.services.adyen.com" xmlns:common="http://common.services.adyen.com">
-                  <payment:paymentRequest>
-                    <payment:merchantAccount><ADYEN_MERCHANT_ACCOUNT></payment:merchantAccount>
-                    <payment:reference>R285069127-MC9VJLCN</payment:reference>
-                            <payment:recurring>
-                  <payment:contract>RECURRING</payment:contract>
-                </payment:recurring>
-                <payment:selectedRecurringDetailReference>8414618459219534</payment:selectedRecurringDetailReference>
-                <payment:shopperInteraction>ContAuth</payment:shopperInteraction>
-                <payment:amount>
-                  <common:currency>USD</common:currency>
-                  <common:value>2000</common:value>
-                </payment:amount>
-                <payment:shopperReference>1</payment:shopperReference>
-                <payment:shopperEmail>spree@example.com</payment:shopperEmail>
-                <payment:shopperIP></payment:shopperIP>
-                <payment:shopperStatement>R285069127-MC9VJLCN</payment:shopperStatement>
-                  </payment:paymentRequest>
-                </payment:authorise>
-
-                  </soap:Body>
-                </soap:Envelope>
-    headers:
-      Accept:
-      - text/xml
-      Content-Type:
-      - text/xml; charset=utf-8
-      Soapaction:
-      - authorise
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 02 May 2016 15:24:22 GMT
-      Server:
-      - Apache
-      Set-Cookie:
-      - JSESSIONID=EEBFF844F4259A7F998C86EBD725AB71.test104e; Path=/pal/; Secure;
-        HttpOnly
-      Last-Modified:
-      - Mon, 02 May 2016 15:24:22 GMT
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - text/xml;charset=UTF-8
-    body:
-      encoding: UTF-8
-      string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soap:Body><ns1:authoriseResponse
-        xmlns:ns1="http://payment.services.adyen.com"><ns1:paymentResult><additionalData
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><authCode xmlns="http://payment.services.adyen.com">83170</authCode><dccAmount
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><dccSignature xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /><fraudResult xmlns="http://payment.services.adyen.com" xsi:nil="true"
-        /><issuerUrl xmlns="http://payment.services.adyen.com" xsi:nil="true" /><md
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><paRequest xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /><pspReference xmlns="http://payment.services.adyen.com">7914622026627838</pspReference><refusalReason
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><resultCode xmlns="http://payment.services.adyen.com">Authorised</resultCode></ns1:paymentResult></ns1:authoriseResponse></soap:Body></soap:Envelope>
-    http_version: 
-  recorded_at: Mon, 02 May 2016 15:24:22 GMT
-- request:
-    method: post
     uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
     body:
       encoding: US-ASCII
-      string: paymentRequest.reference=R038468844&paymentRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&paymentRequest.amount.value=2000&paymentRequest.amount.currency=USD&paymentRequest.billingAddress.street=10+Lovely+Street&paymentRequest.billingAddress.houseNumberOrName=NA&paymentRequest.billingAddress.city=Herndon&paymentRequest.billingAddress.postalCode=35005&paymentRequest.billingAddress.stateOrProvince=AL&paymentRequest.billingAddress.country=US&paymentRequest.additionalData.card.encrypted.json=adyenjs_0_1_18%24X4MGTDe1E%2BnqLcNhPTY8XYkDmWUOaiODBCn%2BxBsgPjC%2BgIQMLSCczd2q%2B84lw7MyN5BVknKhNDM0DgfoweV44zSJ9JJsJ5uNnGtSl5O6WvE13ivLdOhVEZozXiGKi1BXAX%2FFp7Jqj%2BlSiEfcRMea8qEr0iHqgUxOygeNlTwlF1cMPTYMkzCkEiJgFF5vXmml4yeyKSHIShTXTD9ODgA6qiNnRFYgY3Vsop1sP3sDTFG6O2PZkCkwS1vTVGs5FnjsmwfnU6atB3brxqclXn4RMzXH5d3Cajy9tVvEpbTeUzT%2FE5bX5U0N3NZ44MolcaomP8tlJ73qObP8hs7tij498g%3D%3D%24OnrzqA7eB8GmoTfbgGaczV9kvkquiwDGmP9V0X6XCA3C9LZCeeRRmKKbsNMSuV6bEPrFliAWVdHYayRUMaB0%2FtjGTnamrepQxp7Kg3mOEFDUYJLlPCuNVJpa5O83OLAvgrxaXvtNPmQx0qvo9WIi7ZU%2F5uU%2F2ktQum%2F3Gi6vGmjvl99TzXvUFL3tyoji8mwtmbY8M48Me7ceUEi%2BJT9RH0XNgmLUH70h0XTxRntdlMZwKZIkbYGae%2FDR%2BSq1fM2CCf9J4%2FK7hGHp6pAlAs2njJZEMeBEogTiFi0RV5HS8WtJxiJp7%2Fx8R67gQ35S4Hmu%2FzPY0SxMKPk%2FfVJ6TZlk7pvB%2FePvp9ml%2FBL0wQhMlYVTJZ1HRod6Qkt3nAPsakchBbx1aMJ%2Fa%2BZ0zfdlhBQ6dhCAM5DSqv4gibmWliCkzdfzECD0skUf%2FQQ4JW0Paxs73uYqCfJuSxVIdeMUzp0WPNPIvPeAn79cPjjjaGhxmyZuZGWJN9PDFaCfKu3tLITRONf1dE%2BZb%2BuVf6imQz5PYUPm1dWHWz2c7A1XkdbJi6zPHa6vTM2Qq26R7oEJyDF2bKFuiR%2FEBxKwg32gjTl%2FYv138e2iCxCs5I1z%2FBAgfQsG1U0XuElot8QbuLNGh9GT9aNwdlXL86sdQS8OdBj%2FLMZAPyitVJUnn1iNCuo9DWsjlidAKC2aK3IOEV5tzGVKF2tm9Y%2Bz1EtfYpdIOAOL0zlv85RmXgfWT0xOmZ3f%2BPe6102yadiiUYUuZGDFQTaR3ggJBHHNo%2Fsqfy4xXVY2C2NZdo0Q6UINTQSpghS9181pJhSm4gP03%2Bmjl%2BB4VDVL7ZVoHuLfVBmHepr6Xeyag1p%2BJfn2ChyWRuYDAx6lw6HLR0r4ptdZJOLgQh%2B%2BIoPoCfNLhMQ3k%2B%2FxM2M1IltrCn0h0dgXt3E63PfzAn%2BoT0NcxmUis%2BvsxD5IL6vPpEqZuIuhw%2Bo4fW%2B6Numa5mWytmpBv9X2946hlhwhuKyuF%2B6%2BETpbm4y3%2BmMuoQZHr2HmzCtRhX6o1UQGvbgR4ewh8T9hxPLJ7rpm7DwnpjP8I7lc62MZJfd8lpkOUX4sTh4O3%2FLz76VX2%2Bsc9z%2Bc2xxr9FCQ3SIkdesE2mewHgiR0rgMn3JrqSf57z6W1v0aanqXrwsuLLV50uAiDug3rFP%2BefjTb31NzEydyoci%2BUrLhNSUSg7E1fKN8YED0xNJ6nuG%2BBHqCjPQu0chnZ%2B10aDMXKMh65RqS9z9oqR%2F85yjXYufYl5tdCUpRz2kB%2BTbfujfASe3ldWCTbq7iHNp75X0hewmI3ySbIeHT3zOtLpwr7SCjZ9CR35c%2FgUddCg2AR55eyf6QolgC7Fvr408Okl%2Fd1v3RRLHUftha11a4gH%2FeIX64EiBluyg4Dlxp3k6ok4dngSiNAF8C%2BnEdJO3tOxiSkghnKcPqLFIIOuZ%2BAqzBnQ0W8aWBRK0AwUm7XD%2FT0wrleDoWR9ql9bn9y0ELPdPPky9qg51t9u6fNQ%2FcZOlECEKeurjMJwqKzqZgSgj%2FaPw2jAH6OaQSiox708KxAe%2Frw7cij9PGgxHN7BRwFnFaqZIkQF7DEet9MV7C0Hb%2FE11bZOTF2beWiTcOufcA%2B7Y13OO8ISipIW6QFRI0fPXSj42ALhAGACfql%2FfB1JbKy7Kg%2By30SvGXK%2F9PQqGoqzxYhbiOSApIZ6FnEyxajf6fJT9KBgTlE%2Bncv3ZHjrQ3P5RNjsD%2FJ6fFsfGHc79aYBogoD%2F785ECQzFR%2BHBXywWR4h995Bs4ZJcll3i0Kndwvk0nqUW9O%2FHnIZ984o6i176%2BxNhjTM12bOfi%2FgjJPoWLcTclIRftnMH%2Bj2YymBeB6R97oqRSlXCHn5Lxi0e5sk9odYnHLwqQcW15zSrgk5pdWB9PkbefjovPJYvSuBa3erUKQpPEU0Uzlr9LalwOzCjodhzpLC9qWvUiGO4IDWQvMRbXjh0yiE%2BzgC0VDx33bWCUMTCPWlXVmtwhBPF5sKKkjkOayb3hLlnEdbl%2FBbfHpO2i4KKX9Irzp7pSqHqnXCN7ZGmT7S%2FGEOrPIT2n495orefw4oPwX%2B%2BcsHC4WXAT9vph2g5Vtt%2FwDRrNRqmB1vhqVId7UpfU7L9Pp88HWBwIhZNVkn9bOpEXIEOHcb6ivTw3Jd%2Fw%2FEweVZyrlgEWPxQ%2BB0yUIpPZrtAhy4RM5OOzEdAzr1vYNE1KcBaD1gvovR4lVttt7JP%2F2EA9f18ofzlyM2wrHuVWeORTzfT9f%2BlYv4qvVfAn0zsD1EWfRtqSjYyEW2gsGXD8c4OAHWZhlG%2BaqNOLJX%2FHz%2B4%2BmdXzP0FdYy90V3eemXnJlX7SSsalgGAA%2FsCHwBWaPBUmC1E9Aem0TV6BXOiE7DGs2SKAFXOkEvV3I6IayId%2FkKQ%2F4IfDiiimXnBo8HiabE52XPJq%2F1Jg4j1LYTHCqSfboUoA%2FaPjrlWNS5CHjs3vVnVf0uogroOvM3U6nA4k5RHj%2BWOAucOIRKJ%2B3NIyotyq%2BppQtRDMPq%2Be1lstoOD8saOM62ngHErPm0AwTurtiXk2daFgv2%2BD9yd5oQTZdyJwA5EwXh6iGe4ff4n6KLduK8xBh9d9DdiCaUOjBmU5ueob52rDysWC%2FuKbp85dnSpDyGfxAJbRxDDl4Lr771skbSnDV%2Bd1A0YR%2FN%2FGi0EoILAg04dHglsusj8sz687y0%3D&paymentRequest.shopperIP=&paymentRequest.shopperEmail=spree%40example.com&paymentRequest.shopperReference=1&paymentRequest.recurring.contract=RECURRING&action=Payment.authorise
+      string: paymentRequest.reference=R972204915&paymentRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&paymentRequest.amount.value=2000&paymentRequest.amount.currency=USD&paymentRequest.shopperIP=&paymentRequest.shopperEmail=spree%40example.com&paymentRequest.shopperReference=1&paymentRequest.billingAddress.street=10+Lovely+Street&paymentRequest.billingAddress.houseNumberOrName=NA&paymentRequest.billingAddress.city=Herndon&paymentRequest.billingAddress.postalCode=26206&paymentRequest.billingAddress.stateOrProvince=AL&paymentRequest.billingAddress.country=US&paymentRequest.additionalData.card.encrypted.json=adyenjs_0_1_18%24DgN%2FkoPYZnJx0CdlRdsldan4aUmyVPCq7p9HVMOObGzCrIjhKKSp%2BLHiytqv3vMeqnVV1vmVZfJsvkvAXiQiak9pva90UY8eE7OI8ZRdjT4PxRWwje%2FhZ11Onkb0S06XJ%2Bbhqi8oDJ7weqU1grpruhoNDCxI2hJrkzGGcPTefkSUSLbxW3yrLW3FvPTu%2F7O3%2Fu6DkU1QwgCyljZbgALYNnh5UNKD1N80eDkgNrJZEvBfv%2FEcykvs%2B7IojAtjcIyFrz6G2THCcc6APhJDIh%2BbFCwttu9t7YzOn5UvowyBOXuCNyvrPPe2KF08fojL%2FID8ijQiomPPuLXDuUZR1XxX6g%3D%3D%24nPlktP%2FaQMGUwXUQ2NF5nKglnnQhrUEMEcpXe%2FHFIDMLEkwdpxJarMKRBzMpPkqOiP%2BGWedLfRb2QwduqB%2F8aW3J9drxAyYkx2WfjYtzdbCAg%2BLz%2BhzS8tNJNB5yRTnSlAH6hHSwv%2Bsdrgbo5v2TLnzdr%2B4uDg4LgEu8fUT2KwDzS8Edmc7Atqj%2FByrklggurmkcuDbblRvfMnuaJOXHnwHleIcEG%2BUSORcb2hnWOb%2FHC%2BpqR4Rtm2RYBdFlLHAoQGZEpqf4prbqUQZk9LDan2a2cVbO9UWcbgBf1hFUFgUpF8N%2F%2B7Ih4mpymK46YyczT0Fws%2F36QXpPC2iawiwcJjRld2N7K7l81X4cK0cfWK3rOWOqcYG4K7ihXPxu6AS%2F9%2BJ%2FO%2BE2pTeUvA%2FunSbyUv%2FMaziAIR6zgv1EBeHC7SDu5m8Iu3Qp1vu%2FDmuBRQmsKUA9cUMtifSygOoNDmJZGemc5VK%2Fr1%2BMTiFbgPaeo%2FCJPIotL17OGq1WxgprFEImaMZGCSKH60BB1nmAWs8mmSWUoqkvTwFn4182yve%2BFiFVAzV4PEa2mfsWfyzKc19vGkUa3pXVxyd8b1r1xdHFsVsDPfbfNHr3Rco2OhtBMUoKBdlczik4bjb2Cjp5b%2F5q5f55e8V6Fjrb3oeofXYh9Kq1CyCc5ctApa8Pu7Aja3OpGc1wCncQx3vCs7g2UJzEbh8Vkond2eSiv%2BAgv929loxbOWrDvU%2FboWaVg2hbbTA%2F1%2FzZgP2zEeHdoc1sdkZxQNjwnSMRA0bQ%2Be4upyxo6I84537TK4QLVe1pPn8HDwOxBzMW%2Fv7UpqsWr%2BNGixRmEQlS0igfPzCU79gFO0nxy77RoHc89n7MzEpfkhJRso9Vun5SRCE44P93ibOvC1ChhyLEO6aFlFLgUnuCNgSuD4sjiAQIGvD3E0fGpq5TjXd5583MSrEHFjKGJOAglrhO%2B7MQbDs9TA51HEhwpKnWracY%2FPoeH52C5CQSmHAY0BbYHyRGsoilFFGSf%2Bvjgy4ax1pzPmzhtceBcg%2Bd%2FaXgWcm1cIekcojcBvU2khAAYX5NB%2BGKDK2y4qweTOJ5IInxxURO7UXQRkM%2BoSVuDgtWpJyvjqwVqIu3L0dJC92tHPPmkUJEuKomBEsj7r%2Fpn7j8ibjXUpsDjQgq3xURsgQ4rCeRmBMi0%2FL%2BQH%2FodOmps55CNcMw8hQkSbFGNC6FwZWWrijsKerpLvbdf5p6Qat5vGrkMgM%2BsJUar7SH2E%2Fhr0MIyRnaa0hMF%2FgSkAkgVppLqeYzGB2S07WQJErqZHVzj6XjyoGmW1u3g6koXWVGM%2FG3Klq3SmmuX3IDggP8CfOhMwVVPFMDNMvLD%2FkeCh6nOdP5OZxUAPDPwXfbLY0jj0AB4y6fYsz2hGsQTcBVTp09CJ0NpPE0%2Bv40vA91un9lGpOFeS4NZyrRA2A8PpZfEnlVnPEpaeGPRZ1xBGFmVSV23Oq4jc82Gw3Fi03eVc8xT6iMlwNnFDufxvQ2qi7cNFdEC%2FjZxv5e2B1%2BXBG%2Fk1s0h3sMGU9UzS3f%2Bqh0OyzWsCaMi1EbcTiU19on0MMEr9WwCoAPviZpHH6e8obmq%2BTG1g6TFAqNEIBCWuclYgz30PPaiiFS4hRWgpZ%2BTy8F6rxR1loRu%2FNYfu48Aate89QPPEYWX4RfeFb2JgoiwemfjU1vtVV%2BhMTox2d3kGq2McDBrpu7uK%2F6nhgY%2Bgv2jpo4Zy6vkHR5blUld%2BLohGBi0oiYBGXJr%2F71v%2BgklvX7sBXMbHK0gJdGOssYBvPS%2B84eTy0kfQ4uUCDj0ekpsOKQ3ubVWgfj4vq0NnUebKNrWJP3%2Fn%2FXylPhZR7eqFaUvE0C8lpXDGdW2du2wbai965obHHdlX9dtIRSbjn7LHn6MiedvLNHtccuPO8%2FkV1XDOEfB16EBHgdlB3su4R5YxCHHxFhkM%2F71bWBKqocmDmVQjeen2ppywocM1DYnrfmkJjfd7IoT%2BI5LfjlZPgqPOCvJWQzb6naIKd4VBZRnXqMK0%2FXDrD4L1zwj3OUZjGHcWR%2BJ5gdhJSvqtZp4Jsvn%2B2i5PsAXUhtyDBEKLqaZQSmielXlFS5UIf22CqZ8JPMKUOXnC0vioPIoCW%2F7YlUAk9d3Ksb7LcRCBwgc9fct44LNUvljEFJ%2FL1qpJhQuDecC%2FbLFxBahPCvQ9TfbtXOE%2BaTfD57GGAP5AAHmkD2dWTG66sDzwhMgwncJtSMR3bI81IsjRFOjMcA4SirfK3iecbqw1qD1RwhSdAnHl9y4HFhHFev1XfP3hlBAE9bROW25tYqI6SqHibly548fCwlTrw8X9T1heOmIHMpL7FNbP%2FW4axvsCD4vTWdSvkP34oQvIkGDlzfHu6amfM0%2BiG6U1byV8tzXo6%2FZBeyazM%2B3Qa159IJTYLp8kX9EaJZ8Sj2h3wr7Du81P6Iy%2FUavBoq%2BVOLEWrL997DzIZLbJjZb%2BzspYmBWxhLNG%2FENtSD000bvkAZixkUQiFfOI1IQf8JoXb6d1LYaMo0L4KH8I3lt%2FmNcZeNyE6Pcj%2BtRatoRLhbgB%2BC%2BjxpPRlq7ZZU6mX1CecTzUcR0DMT51ed4cPySH94R2FVE%2F3XW0uem91c1P9zeVQC%2BFDFtY723P9YsnFPIywo52EE%2B9Jt1I5Jh8sJbPoGWEQRDRxn3D2EE82MUaNzVokoDj621YoxmHE%3D&paymentRequest.browserInfo.userAgent=Mozilla%2F5.0+%28Unknown%3B+Linux+x86_64%29+AppleWebKit%2F538.1+%28KHTML%2C+like+Gecko%29+PhantomJS%2F2.1.1+Safari%2F538.1&paymentRequest.browserInfo.acceptHeader=text%2Fhtml%2Capplication%2Fxhtml%2Bxml%2Capplication%2Fxml%3Bq%3D0.9%2C*%2F*%3Bq%3D0.8&paymentRequest.recurring.contract=RECURRING&action=Payment.authorise
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -244,20 +21,20 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 16 Aug 2016 23:31:54 GMT
+      - Tue, 08 Aug 2017 23:28:50 GMT
       Server:
       - Apache
       Set-Cookie:
-      - JSESSIONID=3BB552EACEBDD3F04DD3E6E6CF6AB82D.test4e; Path=/pal/; Secure; HttpOnly
+      - JSESSIONID=1CFACF1CC3AD58F8030E07B9EE7A298E.test103e; Path=/pal; Secure; HttpOnly
       Content-Length:
       - '108'
       Content-Type:
-      - text/plain; charset=UTF-8
+      - application/x-www-form-urlencoded
     body:
       encoding: UTF-8
-      string: paymentResult.resultCode=Authorised&paymentResult.pspReference=8614713903144798&paymentResult.authCode=11028
+      string: paymentResult.resultCode=Authorised&paymentResult.pspReference=8835022349302033&paymentResult.authCode=66168
     http_version: 
-  recorded_at: Tue, 16 Aug 2016 23:31:55 GMT
+  recorded_at: Tue, 08 Aug 2017 23:28:50 GMT
 - request:
     method: post
     uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
@@ -279,19 +56,18 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 16 Aug 2016 23:31:56 GMT
+      - Tue, 08 Aug 2017 23:28:51 GMT
       Server:
       - Apache
       Set-Cookie:
-      - JSESSIONID=8FA1E9591CAA6A7226AE84AA03428DCC.test104e; Path=/pal/; Secure;
-        HttpOnly
+      - JSESSIONID=1D1262E8978657C7993185AC52A7171F.test104e; Path=/pal; Secure; HttpOnly
       Content-Length:
       - '1712'
       Content-Type:
-      - text/plain; charset=UTF-8
+      - application/x-www-form-urlencoded
     body:
       encoding: UTF-8
-      string: recurringDetailsResult.details.0.card.billingAddress.stateOrProvince=AL&recurringDetailsResult.details.0.variant=discover&recurringDetailsResult.details.0.card.billingAddress.houseNumberOrName=NA&recurringDetailsResult.details.0.card.holderName=John+Doe&recurringDetailsResult.details.0.aliasType=Default&recurringDetailsResult.details.0.firstPspReference=7914713873061724&recurringDetailsResult.details.0.alias=M512442788467272&recurringDetailsResult.details.0.card.expiryMonth=8&recurringDetailsResult.details.0.billingAddress.stateOrProvince=AL&recurringDetailsResult.details.0.billingAddress.street=10+Lovely+Street&recurringDetailsResult.details.0.card.billingAddress.postalCode=35005&recurringDetailsResult.details.0.card.number=6611&recurringDetailsResult.details.0.billingAddress.country=US&recurringDetailsResult.details.0.billingAddress.houseNumberOrName=NA&recurringDetailsResult.creationDate=2016-08-12T13%3A47%3A25%2B02%3A00&recurringDetailsResult.shopperReference=1&recurringDetailsResult.details.0.card.expiryYear=2018&recurringDetailsResult.details.0.paymentMethodVariant=discover&recurringDetailsResult.details.0.additionalData.cardBin=601160&recurringDetailsResult.details.0.billingAddress.postalCode=35005&recurringDetailsResult.details.0.card.billingAddress.city=Herndon&recurringDetailsResult.details.0.card.billingAddress.country=US&recurringDetailsResult.details.0.card.billingAddress.street=10+Lovely+Street&recurringDetailsResult.details.0.creationDate=2016-08-17T00%3A41%3A46%2B02%3A00&recurringDetailsResult.details.0.billingAddress.city=Herndon&recurringDetailsResult.details.0.recurringDetailReference=8314713873062304&recurringDetailsResult.lastKnownShopperEmail=spree%40example.com
+      string: recurringDetailsResult.details.0.card.billingAddress.stateOrProvince=AL&recurringDetailsResult.details.0.variant=discover&recurringDetailsResult.details.0.card.billingAddress.houseNumberOrName=NA&recurringDetailsResult.details.0.card.holderName=John+Doe&recurringDetailsResult.details.0.aliasType=Default&recurringDetailsResult.details.0.firstPspReference=8835022349302033&recurringDetailsResult.details.0.alias=M512442788467272&recurringDetailsResult.details.0.card.expiryMonth=8&recurringDetailsResult.details.0.billingAddress.stateOrProvince=AL&recurringDetailsResult.details.0.billingAddress.street=10+Lovely+Street&recurringDetailsResult.details.0.card.billingAddress.postalCode=26206&recurringDetailsResult.details.0.card.number=6611&recurringDetailsResult.details.0.billingAddress.country=US&recurringDetailsResult.details.0.billingAddress.houseNumberOrName=NA&recurringDetailsResult.creationDate=2016-08-12T13%3A47%3A25%2B02%3A00&recurringDetailsResult.shopperReference=1&recurringDetailsResult.details.0.card.expiryYear=2018&recurringDetailsResult.details.0.paymentMethodVariant=discover&recurringDetailsResult.details.0.additionalData.cardBin=601160&recurringDetailsResult.details.0.billingAddress.postalCode=26206&recurringDetailsResult.details.0.card.billingAddress.city=Herndon&recurringDetailsResult.details.0.card.billingAddress.country=US&recurringDetailsResult.details.0.card.billingAddress.street=10+Lovely+Street&recurringDetailsResult.details.0.creationDate=2017-08-09T01%3A28%3A50%2B02%3A00&recurringDetailsResult.details.0.billingAddress.city=Herndon&recurringDetailsResult.details.0.recurringDetailReference=8414725049542679&recurringDetailsResult.lastKnownShopperEmail=spree%40example.com
     http_version: 
-  recorded_at: Tue, 16 Aug 2016 23:31:56 GMT
-recorded_with: VCR 3.0.1
+  recorded_at: Tue, 08 Aug 2017 23:28:51 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Credit_Card_Purchase_Process.yml
+++ b/spec/cassettes/Credit_Card_Purchase_Process.yml
@@ -2,226 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/servlet/soap/Payment
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0"?>
-                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-                  <soap:Body>
-                            <payment:authorise xmlns:payment="http://payment.services.adyen.com" xmlns:recurring="http://recurring.services.adyen.com" xmlns:common="http://common.services.adyen.com">
-                  <payment:paymentRequest>
-                    <payment:merchantAccount><ADYEN_MERCHANT_ACCOUNT></payment:merchantAccount>
-                    <payment:reference>R964158744</payment:reference>
-                            <additionalAmount xmlns="http://payment.services.adyen.com" xsi:nil="true" />
-                <additionalData xmlns="http://payment.services.adyen.com">
-                  <entry>
-                    <key xsi:type="xsd:string">card.encrypted.json</key>
-                    <value xsi:type="xsd:string">adyenjs_0_1_18$n/C2NDp9529vaFGoy45ANtmkEq9SUEQV35VG4ZSEjVCMt6lisGpUP4B7/jVvwGrmwJmklwd08baKDT8zo98TEd3zFeVWcmGShhIVDu6W9Y96q8nH6C9fLnfPw2Q7ZOnB/dZjk9ZL4lQQ6H8ClyMMMKgAM1W2zYG30poGuIE6mrUnTnp8xEYzVgQRajk5/VTuPFOtZYLLrLnOZc0D9WC0u2ZAOJxc/r/zmqef7uZftu5GMM96eCFXJl2uiRVypmWdn2THpucJ3PsTUPqQXmFyiRdn0pA/dRjMfbYAo6T44JKLz0uDf+jblPS1ddGNEYBS3wXMbEV+ph149eTNnowZWw==$dRCk5PCERFlTEMvC2Vt80kJMFKNquzfvrTFKb1oV7gxpmxktYysg510v1txdyM3ncy9ZckqJf66A0B19RL3gLAK2+STebpUkk8s7SRG5jgTcmajEcrkY9henHFwilT22uUTBe4Mi/9PRlaJXN2EKcY2cY/17vf4uioMfq7tNd+B81jXmTCLvuuqasUEdD9k/RvV1aNfWGpmowIgYn2eDK3YBqWXG0z6upxnLaIAeaseVAyIQzScsFogalMlKh0Hskhbi1Usn3nsIdsNXbEJVvqnMChTnO4RXBcHQsTy8YaF++PBGG4JlJor3qeFMkjcwd2li2oYFnA4Ss83jbyqv9M83JrhGFNycspc9SGQXjjofLOOLWGOqVKSsB25fuWZ4LXkXq3tbRjrRs/HxD9M/W9IVcdkm4+J1LPSudEbNuKFG5/iu+ZsCmbFbiOUyAQolnmK0SBwGJ9fASgxim+oL8gP9NGrE5PzDPO75S0NeiZMVJ1mzKOf58V80axDFm67vR/sWGEKwrYy5S9TGTWEhQwk55kAkAhXlbM/19ZopgJbv45yviS6zU6qYh/FUrUVNqjy5oZqq5xgm6Fg6YGb+xWcf4cakOc/zgmUBMUVvGp5+z/QXd2gH1cvDJPcVDtKqTuqI1/QXJ9iW1O5V4ktAPN1jLOvSI0jEE9c6NWxCDw1T2naMKSDLQVpGX4o19FfY8PSE0KL/eb2jJ8M4vpQbgyXq5b51FjCjVYGQS3e7DgKeN9iPmlVC5s7UbVheDGlFZqO6npJ2MylGOB7f8ZkXyKDDQsxtg+myl5rdgJvYFU0v0NNA7bXonrXnQB4SWj/HarPDL0XeNQl0oNWpnkkRD/yQs/Uhzn49AoSY+TZ8VmXKvkmANGAy/P+YMvKTL4E1tOFaOibMxklPYd5cezOUw6wuU66d92s2PdkyxPfqHCtnQCClPqlPkgs/p99M+oADfI0v1ZoatM3wEyl/I5JzdtQJXwVFsOkDTH7hwDcD+jcECyYaq3lTMFyKHmSTYNltnaMbcC/OYxsQBNIBz4IG91Qjw1VZUeiJA4T/drLQ7Q34XiBZpgXK3zSehgXHErwXFiSLPzyk/cUtK6pAvKmyknd6mUA1d8QZLhVt5lHNmi5mDl/5IFXxPCGQc0M+CnDcfEfzfH5L9cjjR+/FR7mJvw43jxdWMigNVTPxMhMWPRlRdnzQ+2b4L6wf54UXDBOssSdL3wiSj5+tljNl9O5L+KmQbINsZCErfGegnnLgJBwmXUGlBkpaurFr0ssfkx53zs0+Sz28pQjeJPqS3EE8WGBA8s7dQJiDYfb2kJsy14B8EWwYbiAJxPs61uuMXfb3v60Tw8OTpbs7hNvx9e6MCYvZ32DENzxTKGFoD5TM2j11UuDJWpl4hUUuR5qH5VUOHTevQeRfcs3ZJ6R54dwrFZMeNxlBN0hMBd6geOCJLN7YbG4JJ75U0g+G3mLKFTCiZgRgeMpCesbfswXfOUHFvOT/MIUPL3kYnDJjQJcMEzhJ9Q5VL9FhJgVV/nWdUcKjgD9oxwtvrNvUm8PobOBz8QjJoTMplYJJeEz9Cqy6zwm1l7xFa8Oj9vghq90FLwL+jqN5tHqxV0vJO7dqeqWpfoBCVLEsBDpGyriBWTU6QUHjrGMwxwZBAUe+aMXocukDHb8vDafNKudxiKHs2HvFuRAx+lV3plwJK2utJtkSY0vJMvHnRFfKbLPMtG4ALOClRfEoxxY+NMD7H66ht5M3hh7U7mquSvNrPh6cI/wv8Ett1VVoe8Pl9kTt0rwnUBgFE8V+Xy2SOHzPM3qU9sgW1erlzi0iMdUYaG4ViW3VlV0JP/fjxFOX10MzL/K4+Ji7A23dLqNg6593VTC5y1qONrDu9iCyCBFnZh/RFkzAsUpzX4LhVX/eRZ0O7u7cd4c9LNdrtV9GE217y1RF0UatFZQecDQtvQbf0+Eub7II3jbVPwjQ1yR4e2qlV+WMigHnTgVsqmp4+1lMqVUs+BO7kKKSZai8ziCxLTu4HNxisQYYwCGQUukvS81cI9UClRxL9wrbkdIO98n/bGFmu9DHDZ7C6e2bKJlmteP/1Lgh+ZJTfo8GuHo4f5ddvHqdwEtvNVw0gnDQ+sUqmohL3GrKeCzrUg2Nn7REjEUjeZPwcpqbaOmhDRdr2BIWCH7+1Og3C84gjb6MLoAm+cnCRb/DvkRCqZZRr6RP/LNKnZxOTNMeVu7+7iTRdITlh6fWqKcLwMz2NqW50t57bNnpYravNaB9hkuV86wmhit9IGN+CFIU1skOFO1ccVx+NMOt1ydgvWvN3Zt0RDmEEFDpFUqoDrtMTMYa5FgFrQT60beJvEw8wbvDCXheZ4PKIri7+7OjmoKIOvDpsvUAHh5StgVzSAjW303SwiUTdfbkhQaCxtJH6Dz1c5hm2nexdA==</value>
-                  </entry>
-                </additionalData>
-                <payment:recurring>
-                  <payment:contract>RECURRING,ONECLICK</payment:contract>
-                </payment:recurring>
-                <payment:amount>
-                  <common:currency>USD</common:currency>
-                  <common:value>2000</common:value>
-                </payment:amount>
-                <payment:shopperReference>1</payment:shopperReference>
-                <payment:shopperEmail>spree@example.com</payment:shopperEmail>
-                <payment:shopperIP></payment:shopperIP>
-                <payment:shopperStatement>R964158744</payment:shopperStatement>
-                  </payment:paymentRequest>
-                </payment:authorise>
-
-                  </soap:Body>
-                </soap:Envelope>
-    headers:
-      Accept:
-      - text/xml
-      Content-Type:
-      - text/xml; charset=utf-8
-      Soapaction:
-      - authorise
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 02 Aug 2016 18:49:14 GMT
-      Server:
-      - Apache
-      Set-Cookie:
-      - JSESSIONID=CDD2A090EB47E6CA081C677554458C0E.test3e; Path=/pal/; Secure; HttpOnly
-      Last-Modified:
-      - Tue, 02 Aug 2016 18:49:14 GMT
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - text/xml;charset=UTF-8
-    body:
-      encoding: UTF-8
-      string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soap:Body><ns1:authoriseResponse
-        xmlns:ns1="http://payment.services.adyen.com"><ns1:paymentResult><additionalData
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><authCode xmlns="http://payment.services.adyen.com">30778</authCode><dccAmount
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><dccSignature xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /><fraudResult xmlns="http://payment.services.adyen.com" xsi:nil="true"
-        /><issuerUrl xmlns="http://payment.services.adyen.com" xsi:nil="true" /><md
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><paRequest xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /><pspReference xmlns="http://payment.services.adyen.com">8514701637548229</pspReference><refusalReason
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><resultCode xmlns="http://payment.services.adyen.com">Authorised</resultCode></ns1:paymentResult></ns1:authoriseResponse></soap:Body></soap:Envelope>
-    http_version: 
-  recorded_at: Tue, 02 Aug 2016 18:49:14 GMT
-- request:
-    method: post
-    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/servlet/soap/Recurring
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0"?>
-                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-                  <soap:Body>
-                        <recurring:listRecurringDetails xmlns:payment="http://payment.services.adyen.com" xmlns:recurring="http://recurring.services.adyen.com">
-              <recurring:request>
-                <recurring:recurring>
-                  <payment:contract>RECURRING</payment:contract>
-                </recurring:recurring>
-                <recurring:merchantAccount><ADYEN_MERCHANT_ACCOUNT></recurring:merchantAccount>
-                <recurring:shopperReference>1</recurring:shopperReference>
-              </recurring:request>
-            </recurring:listRecurringDetails>
-
-                  </soap:Body>
-                </soap:Envelope>
-    headers:
-      Accept:
-      - text/xml
-      Content-Type:
-      - text/xml; charset=utf-8
-      Soapaction:
-      - listRecurringDetails
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 02 Aug 2016 18:49:16 GMT
-      Server:
-      - Apache
-      Set-Cookie:
-      - JSESSIONID=D72FA4FDC552AF5D879F8C788AAA7BA2.test4e; Path=/pal/; Secure; HttpOnly
-      Pspreference:
-      - '8614701637568598'
-      Content-Length:
-      - '2697'
-      Content-Type:
-      - text/xml;charset=utf-8
-    body:
-      encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soap:Body><recurring:listRecurringDetailsResponse
-        xmlns:recurring="http://recurring.services.adyen.com"><recurring:result><creationDate
-        xmlns="http://recurring.services.adyen.com">2015-08-28T23:27:19+02:00</creationDate><details
-        xmlns="http://recurring.services.adyen.com"><RecurringDetail><bank xsi:nil="true"
-        /><card><billingAddress xmlns="http://payment.services.adyen.com" xsi:nil="true"
-        /><brand xmlns="http://payment.services.adyen.com" xsi:nil="true" /><cvc xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /><expiryMonth xmlns="http://payment.services.adyen.com">6</expiryMonth><expiryYear
-        xmlns="http://payment.services.adyen.com">2016</expiryYear><holderName xmlns="http://payment.services.adyen.com">Test
-        Tester</holderName><issueNumber xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /><number xmlns="http://payment.services.adyen.com">0002</number><startMonth
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><startYear xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /></card><creationDate>2015-08-28T23:27:19+02:00</creationDate><elv
-        xsi:nil="true" /><name xsi:nil="true" /><recurringDetailReference>8414407972394291</recurringDetailReference><variant>amex</variant></RecurringDetail><RecurringDetail><bank
-        xsi:nil="true" /><card><billingAddress xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /><brand xmlns="http://payment.services.adyen.com" xsi:nil="true"
-        /><cvc xmlns="http://payment.services.adyen.com" xsi:nil="true" /><expiryMonth
-        xmlns="http://payment.services.adyen.com">8</expiryMonth><expiryYear xmlns="http://payment.services.adyen.com">2018</expiryYear><holderName
-        xmlns="http://payment.services.adyen.com">Luuk Veenis</holderName><issueNumber
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><number xmlns="http://payment.services.adyen.com">6611</number><startMonth
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><startYear xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /></card><creationDate>2016-07-04T23:05:12+02:00</creationDate><elv
-        xsi:nil="true" /><name xsi:nil="true" /><recurringDetailReference>8314676663125237</recurringDetailReference><variant>discover</variant></RecurringDetail></details><lastKnownShopperEmail
-        xmlns="http://recurring.services.adyen.com">spree@example.com</lastKnownShopperEmail><shopperReference
-        xmlns="http://recurring.services.adyen.com">1</shopperReference></recurring:result></recurring:listRecurringDetailsResponse></soap:Body></soap:Envelope>
-    http_version: 
-  recorded_at: Tue, 02 Aug 2016 18:49:16 GMT
-- request:
-    method: post
-    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/servlet/soap/Payment
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0"?>
-                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-                  <soap:Body>
-                                <payment:capture xmlns:payment="http://payment.services.adyen.com" xmlns:recurring="http://recurring.services.adyen.com" xmlns:common="http://common.services.adyen.com">
-                      <payment:modificationRequest>
-                        <payment:merchantAccount><ADYEN_MERCHANT_ACCOUNT></payment:merchantAccount>
-                        <payment:originalReference>8514701637548229</payment:originalReference>
-                                    <payment:modificationAmount>
-                      <common:currency>USD</common:currency>
-                      <common:value>2000</common:value>
-                    </payment:modificationAmount>
-
-                      </payment:modificationRequest>
-                    </payment:capture>
-
-                  </soap:Body>
-                </soap:Envelope>
-    headers:
-      Accept:
-      - text/xml
-      Content-Type:
-      - text/xml; charset=utf-8
-      Soapaction:
-      - authorise
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 02 Aug 2016 18:50:53 GMT
-      Server:
-      - Apache
-      Set-Cookie:
-      - JSESSIONID=23DD998B5714EDC46D855DBCA770FE9A.test3e; Path=/pal/; Secure; HttpOnly
-      Last-Modified:
-      - Tue, 02 Aug 2016 18:50:54 GMT
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - text/xml;charset=UTF-8
-    body:
-      encoding: UTF-8
-      string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soap:Body><ns1:captureResponse
-        xmlns:ns1="http://payment.services.adyen.com"><ns1:captureResult><additionalData
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><pspReference xmlns="http://payment.services.adyen.com">8514701638539177</pspReference><response
-        xmlns="http://payment.services.adyen.com">[capture-received]</response></ns1:captureResult></ns1:captureResponse></soap:Body></soap:Envelope>
-    http_version: 
-  recorded_at: Tue, 02 Aug 2016 18:50:54 GMT
-- request:
-    method: post
     uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
     body:
       encoding: US-ASCII
-      string: paymentRequest.reference=R882762483&paymentRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&paymentRequest.amount.value=2000&paymentRequest.amount.currency=USD&paymentRequest.billingAddress.street=10+Lovely+Street&paymentRequest.billingAddress.houseNumberOrName=NA&paymentRequest.billingAddress.city=Herndon&paymentRequest.billingAddress.postalCode=35005&paymentRequest.billingAddress.stateOrProvince=AL&paymentRequest.billingAddress.country=US&paymentRequest.additionalData.card.encrypted.json=adyenjs_0_1_18%24sqrkU0pVXetmCn2j0puZxOF2xG5MYvomVZrRbC4FnLDmNzsekkC2eeJnBXRiNTs8afJ6ohYeRGIc6kBAkOgKfgqDicbjKNx70xjHmApIUXv6JEAR%2BOK9W0p2SRX2xtlmHeXEuZ4l%2FgOgjDPbc0qohT5VOFFKl%2Bv24vbusqKDQ2kBkFS430AKG1eDF2UDigUo8FgqWCMeztk94r9wn%2FNm0MZ08mBF1CWfHuKlnpd6NNulM%2FVn1fhyUVOVyh5gYC17hh6K3%2F028SR94nD41ou0db1YodqhmdbivMYWfA%2BvogIxZhYJKfJ1NkoXXxMxdSK9FY3%2BFKRWa%2FsodEr1stqvAQ%3D%3D%24xgB7KuOnxOQ%2Fm8AQ1RMqBefkVdgEa83wbPUmGF%2B5poq83rUfVzLXDUaWxZxZUnz5lybXQI%2F3eM15q2c6iGY%2F14zbAymDb2H1PwZvWwFvXhCw8UbGwbDWnHCsti7btgckF4jp5ne6wxjxKDaucNMUozjLOHC7NSPf0%2Bz5yiRIEPIsBqidkI9FtTyGgU1NGwIyzvHTVVvKNW%2FOGTV1IvB6amP1WNUod0svi8Iv%2FSTLK2OFpdgQPZHeOmJ%2FhcF1wGgYWiaM1PA2lQ9mrZuLDKfrvZuR43jnnZEL6OPEc0QqqgIYs1mSuFW%2FJfg7vtktkT6ATT%2FI1NmLLYTE%2BKOTHuZ5L2BPu5pJW%2FlN7rcw8jp6y3bj2KavrN5eps6VChU1Hy5eLG4xlrik%2FnnS0UQMo0gj%2B8%2BLQhszzeqolnqcWFXZBIeNmqbMD9zFKieqC9i23lMhTa4kVgKSO4f4GL3azl9%2BHsCLB60Nk6ijXX56M2tP6aKqRVn%2BQjh3U9oSFdOcvdnpRTb6lVbHkQZDVRXeKfAOG85Ti2YhOrvs0QaDnEGBvO6qCTeqNw6rWtb2DLl2IKJP2MSSwHJd5YhjKSiMwiWnO73oDPqUoS0xLVeFi%2B36Jsi6cdsvU7KeEQrpOzX7HPW3HDy%2Bsm42KSmSbRqg2UpCG6tXoeLWy2akuxxmYouwmcctUxPek8odBYVQqPsbKxzdCTTwIR6KtGcHeeHGh2OBlrf7BosnLxisiqnqaQt6KYK7dQoUarsI%2FoKZ7P4fG1SCLTPi%2FYDVblahGlCBdG8h19S5t0VmX%2FHmqZqbH9GPTQRyKRbsSw6WBW9u8TbIP8vY80UyRVpdGAxwmkBF7l0G1Bf%2B1q5cC%2FqnMOSvlt7RLIiQo%2FQCgGA0fZgYqFQxDo%2BqC2nfotE3jA7LOvt8p9ryATlR3WlcwUt7deki%2FeNCZsbxT4LKsqnTRoc1ywJMXMsmZtIa7AXIOFhGDailTUFzHki8RmRiv6%2BvjRVNCgJbK44vOV6E9PJwm4JqXDFsEr24ziCBco1z4lCTtm8pVDaMRpcD23bBKjFG8TlNdLK0sIlM7DMxPZbTo3N%2F1Mx9E2c2zUb0pz%2FE7CFuA4nYVLBWGVdlnLj7EZNyOXMqp%2FB3aNLky1YCHlMir1uDr0r%2FjpFRAIX2Obyy0guiHVhzrMelnpQlvfZqRWPR8kQXKy2DAc%2B7qm0jZocAD8F9StbWGEsGQ9vpSMkK%2FrksfACOhTJlt4MNUfx1laba5%2FhAw5y4y6r3SH3QQvv%2FnKG9874IBzkG3KrUZP2UfGSwI6Zz1thrfDXZDIzq2o2O9yRSG9iMaJGevEcw3lVyJyU1GYR6fkS4lZN2wgHKhNO7qBPdv%2BWnNTtOfNcrp0Pmy%2Fpdg2g0dTklpNGU%2FGuNBalb0dlco4WiPZK174c7rUgP6ZmEKu0AjgaCbCBgfqFxeFen6FkIUtylI2HFBwR77w5O%2BJAOPDyK%2FD4XRD2QU5Apa3vdndrMYr1CZa95CZlTyopf0L44VL8jYyNADINeXKPoby6dE%2BK%2B%2BqjGT5yBzGcIakz8n9RdEFexoFPVa1yKVNS69e5qvSyLpRkAgLhiGBLsfMTVCHS4zb93S9wgWvz3yMZzhaOIUa9pEzXDNapsnqnG9e6%2F5AzyGtbA77xJqfcpoFgwoVAwdbxss1HX%2BjvUgmSQIcnOkbF9sFPrqZkgZeIASWQ4ynw%2B7sMpMN1bDoHUOKXBzrUDCc%2F1rNuRalkG%2BtrdjvQ0Roqmqb0Glo73kHWQyoIKCEqsKClQVfLeukCxPsA8qetAxvX8GH9bAIjDedE5jk%2B4wDqjd7kTryiFewPsVNsPtvkD9Wq%2BoSiHlY3MyYBB9uiD7XgCgOKvM9xYiwiXJRJMDQ0SbU6HAG8s4gLZ9d%2FkB9IeMK6ij8sWtdc1z5alUTUFfQ1OYmaPyC8DZLClxNXVhek6T7swAyFLo4P7CmFGpL7wUS4Itj%2BrK%2FOQo3LsVgxT8B3HHWIAsaUawELmQmY5yp9IY8%2Fovss4rrluevnX14X2n5M6BqBbRr%2Flbdr4uJrMIySkh2ci8nUlysIo1Tj1lCL7gg6y4YIqrdyJI3Ip43kDHuN2jsEue8UmM85kImNp5%2BkWc%2F8h2l5KFan9g5ArilIib%2FlN%2BW9J1ikl9OJwtHVWSPMsfx7fmIJwJPDEMKsdAkvhArSXruWT6zaSfmVGEwSBdkCvNCgx3nKq7s2EkvgUpAyGyiA3%2FZ46GNBY%2BDKE3fyKVCri%2FwG3zUrkOD0bxf%2B6kq8vmWwfP%2F3B0CPjN1eAGij6PRy%2FWmFW7Hf4fyCMnFM93yhFOIJhPlGTv2iE1aKIo%2BxAbvmFW5twfPOP%2B9bzcuuoylVcqZzBwTerV0vvV5H4eDlliY2c4fmM3ZC%2FG%2B7Owo%2Fpyl8elIyt6YaMLtuYAZQwlNJRHSzRD4iFqGALGuQpxl%2FcTbIIrVJ5JZZXULEx6Fe2iFD1%2FPn7CJzWOvtRj2bnDhaRbKsTwbhf08QwOysuqrRToW4td%2FRqzmujWPZcwCCPsf9f%2BKhiAmmqdTHS9WBRvuFSgIIoiqL8aM1uKfOV%2Bw1jRZKZ%2Bj5uPAnka%2B8MofU7D3hGJ%2FcE%2BOLavV7uHrD25KcI2XCMJlgGdIOXsT2FEKvnHrrGt6TuKF%2F1KcygO6BtkNuH8V2i3YO2FjWnNOzrkslrMBM7lx5XL89%2F8JH6FmN7DnE%3D&paymentRequest.shopperIP=&paymentRequest.shopperEmail=spree%40example.com&paymentRequest.shopperReference=1&paymentRequest.recurring.contract=RECURRING&action=Payment.authorise
+      string: paymentRequest.reference=R093790928&paymentRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&paymentRequest.amount.value=2000&paymentRequest.amount.currency=USD&paymentRequest.shopperIP=&paymentRequest.shopperEmail=spree%40example.com&paymentRequest.shopperReference=1&paymentRequest.billingAddress.street=10+Lovely+Street&paymentRequest.billingAddress.houseNumberOrName=NA&paymentRequest.billingAddress.city=Herndon&paymentRequest.billingAddress.postalCode=54370-6198&paymentRequest.billingAddress.stateOrProvince=AL&paymentRequest.billingAddress.country=US&paymentRequest.additionalData.card.encrypted.json=adyenjs_0_1_18%24zcUKCMThEl3QD590bnASVyL9znF96YsvyV1ZuhdhRmjxJMDqkcmNBPGd7fn0rgV%2Fu8dE5L%2BYDSbZRM%2Br1e0fhFBId3xAPCHImcTVYBp8Qkbaujy5jyzibLjHrwgAqMe0rg52XY31X88DjJjpDx91jvVw8u9tofX0%2BzEnubxFiF70MVGey1inIh3X6qKH%2FGlI4L1LFfscR5aq455YxOP%2B9I6jjtu8H%2FaZgRM%2FcOLme6DGhOx6tJ1x4yb285RgaPztZjMZPjH6U1k8WLP4ICNizDVu4UGTUMcuAEINOELfSo9mWO9TmFpDv407sGYS%2Bzi19Rl7DvpR87l1JIg07wnlDA%3D%3D%24q9pajGcOrrT7%2Bvf8G76Hd8Kkpyc0oT9HXH5qnoOhkWe2l4s%2BBLVqKQDcv5PgCUVfjQp%2F98B%2B6yWhZTcC3On4L0sJeYBlnGPSY0RSOjvFpKXqo7bA7wf8bsqz%2BQ6JQbPYm0bvuo5vJ4SR78QhL%2BVUuxtgLN2qw5XLfOv3HRIqlBoFekHF3DKWbstpoWn4FjHeQMFO5QbedqxFTViBgdQIYne0XWGwxt83upu1yRfeMCb5HQDrbnnIAJLsRZy3HAYrGp2dudveexc7Ba9TKvByW2IBTYSg7MR7XRPHZ1%2BRAvpq6kRPF8WfMB5OchZOU06f8n74OOh3JzD3W7ul9ZA9XSArlPI90PLH8On7mXCcp4lyfpgIbSjtt%2FTw71qEVGzb38E2d2QhQvYxOr%2BEdWadsuK3olUJCGcFJRZhuVE3qZe%2FFqA1BvQXXRsEB10lkHChbyIPfjL9tEthuujs0SFvviCl1dYcxnXI4GTK1PLU7k5B%2FE9hvM0CeDHjq2ia6JOHIfoav8x3VKqv3D4sUTYbwUtVvyy8CErCefgTP84B%2BtXOcS3i4EiyR6MbbQm3Gg0b4mxq%2FHf2fSZyVvTZf2TgiE9yT6qV5rVhextX6se2vqu1tuFCB2gKFQgsrllkDu8lUq%2BzNDwLYpejz2Z3rqXhwhU41mBrG0qpi58g89UD%2B6gd4WF67HctMGLQww7iyE4EpEiXiFk7U%2BToWg5V032M1JlFe9c%2BmUmgMrj%2B4GIjqI%2F1IkKxmAvlJ8a33jTHHLoXYzpLdpdm%2BHIi2bDSBA2i1Qy4%2Fc9ahfirV8Jj5v8Pjeixc1pcv4cSzsnD9f024uNQR%2BxXcyLn%2F1P9D%2FQn6Vf3wecLfQxsTnH%2F3gdET7UbmWkkmhJBmWgQml5crGjAlCfipq55zVIgChsYdpbjzZIH0aH%2FPQ%2BjqMuSqxd%2B83xkpqbZIFr%2B89MmLWnbwPggadkE%2Fq9xbatNjXv5oUIFxmG7bneaBk4z6gkOD2lFvA%2F0tCuQhDWXA4ztdKatnRDzG1D%2Fs%2BL6ECIzPRHqgYWTbUPnz%2FgoKGo52THAbQMDHR2SGsRpcYk%2F5ClZlZ4XLjXHPkCVtwAFCFc76lFf1Fah8j44sa6LsMa2nsu%2B8xpMRjMZkKwzpQFzkftjKgtglzlyuCytB6lXL2AlkuNjTYrP1fOr6aNzENmqPH4eIJkHdiDUsMa5OVYcDaLZrerOMo5GCYwABkb9kJv%2F1bY2%2BLGRcNYIPhYMK93SopOE5uanFWuCW8aB5rMHqR6RVOOlqE5Em29k76TKu0qOfjQzJjqWsCegITG7TSR4hZ1NnKituHjfRbmgZv1KML%2BGUzCZVD1Yvm5dpNzDtYH3z6vX9X19F%2BLCg5%2BOeAnOAxilmKpjHaRLI8vkd9rZ2pGaQ%2FcYV%2Bu9bGJCb3i8wMFVNbZIpaHUxuoY75H8HkJMCGG2JJbpZUnwgdZr9ZANdaH5fVPE4RsMSRxnhlFrhtXdBLHWmFDv0j2BGZcgcHCIObty3b0lPRU73Oaaxlf66wYv1o5lGf2fEDyqdJkWouUCxxL0IFMfj4Lq6ln7Pl0mVnYk1AjCHb8%2F0OUCLNVNCx%2FIIkqJMsSJe%2BAAihKgoYMPs4MKKg3D9NAypy2pmgbobX2CSkAufnaN6nhj6vSrl0JZvaAUdzHxfEDchMWtc4C0sXApJCyKCG8D4d4KuS%2FmRcSp0P6ndcAqbCHu%2BouJX0x4H5hhZosh37nB0sCd5wgdvduxufRs%2BhrrxE7PAaiTZs3y%2FZg%2BkdBRleYz9Ue7V2jFZ3smFcEzlgOHuGvRE3N2Pu0Cxmxo3AyLvfhIfl8Fj4BSEM3kNV8NnYp%2B6%2FG7myT2fYNORTy2XgcjwHKb9EBpAQXueUpIhbvj6hrx7IaDbO9rTvKtDToegKd8I8HWDP0M7iaRhG3OdqaNzyRqjHusa3WM0HHCB7upDMtG5jUDnQok6zJUpbpKRPC3JiZOuFe%2B2%2BassbpnBNGQZ2oqRuJvaEIf5N4likCyyd%2BXHVEEmyr3IzoU7ANAzb6KBzqTsGhgih%2FhGX4XxS0jgjjgTFM%2BRT05%2Fi4ZcqgtALEonubLSj88T%2F01L7%2FJ7vLUDpHOvOngJAUnoVwjF2Cxe0nhRxWWXQLkd3JrbboYgfeCOpHSTnH%2Fx%2Fp5nhnFXmQ5YfYvi0KDN%2Bb3VNXewRZbYmyShMbz4dXvmtBL1GhxzC0wjtn2vgXUIJM5BrCWIhwsRnYnsMjAAK0DyVldnLLXUQuqsnyL97BEUoazaJUWEXhE58AFMThRqdQF5IXWOiOnqG5SWSI3C5PTicMSbIRimgXDNoKfLeQzBIZUdUpnwn4jfLKmyxRpPjLzP55yPGJSvEF03tGSjQG1aJoBllyZMASdEijKu854k8yN20Rj84HoXOOCrgruqAus3HM%2BhYYzvpGIRY%2FmX49kG49DLuXPXtucqaPcUw2bWTQv8PPQqjLz3X6WkXcBKx6Y%2BPEfrz36k7q1Zwu7kq5P6x9djh4Bz7m9ImFpiNng%2FrWltzeVGhCiI3hcOlZNeZzDklOXXwQvVaYnlzUzaNznMwYBHdmTjhqkBIYMEolPpKGsKNtEzSjHuGwgBY3WRzFh5dGZitJg9pTy6SLsKAjz1cr7nYXdQyNlTrMPPJlnhjxND3m4Dyz6Hu6f80YuZ9u975MoBhC%2Bm8IFzegxR6DcH1SrtMu7LxxK9Hr7bRo%3D&paymentRequest.browserInfo.userAgent=Mozilla%2F5.0+%28Unknown%3B+Linux+x86_64%29+AppleWebKit%2F538.1+%28KHTML%2C+like+Gecko%29+PhantomJS%2F2.1.1+Safari%2F538.1&paymentRequest.browserInfo.acceptHeader=text%2Fhtml%2Capplication%2Fxhtml%2Bxml%2Capplication%2Fxml%3Bq%3D0.9%2C*%2F*%3Bq%3D0.8&paymentRequest.recurring.contract=RECURRING&action=Payment.authorise
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -237,21 +21,20 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 16 Aug 2016 23:32:01 GMT
+      - Tue, 08 Aug 2017 23:28:54 GMT
       Server:
       - Apache
       Set-Cookie:
-      - JSESSIONID=B1027BC56CEAD250B055CACBBB5D500C.test104e; Path=/pal/; Secure;
-        HttpOnly
+      - JSESSIONID=8966F4F239DD552F801AEC9E4A7D2EF3.test104e; Path=/pal; Secure; HttpOnly
       Content-Length:
       - '108'
       Content-Type:
-      - text/plain; charset=UTF-8
+      - application/x-www-form-urlencoded
     body:
       encoding: UTF-8
-      string: paymentResult.resultCode=Authorised&paymentResult.pspReference=7914713903212586&paymentResult.authCode=81834
+      string: paymentResult.resultCode=Authorised&paymentResult.pspReference=8815022349345739&paymentResult.authCode=11184
     http_version: 
-  recorded_at: Tue, 16 Aug 2016 23:32:01 GMT
+  recorded_at: Tue, 08 Aug 2017 23:28:55 GMT
 - request:
     method: post
     uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
@@ -273,27 +56,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 16 Aug 2016 23:32:02 GMT
+      - Tue, 08 Aug 2017 23:28:56 GMT
       Server:
       - Apache
       Set-Cookie:
-      - JSESSIONID=49571B99F6A5BAE1478CAF5CFB55EE09.test103e; Path=/pal/; Secure;
-        HttpOnly
+      - JSESSIONID=48A8EBA9E3B1E2E311F9E701C40ED890.test103e; Path=/pal; Secure; HttpOnly
       Content-Length:
-      - '1712'
+      - '1722'
       Content-Type:
-      - text/plain; charset=UTF-8
+      - application/x-www-form-urlencoded
     body:
       encoding: UTF-8
-      string: recurringDetailsResult.details.0.card.billingAddress.stateOrProvince=AL&recurringDetailsResult.details.0.variant=discover&recurringDetailsResult.details.0.card.billingAddress.houseNumberOrName=NA&recurringDetailsResult.details.0.card.holderName=John+Doe&recurringDetailsResult.details.0.aliasType=Default&recurringDetailsResult.details.0.firstPspReference=7914713873061724&recurringDetailsResult.details.0.alias=M512442788467272&recurringDetailsResult.details.0.card.expiryMonth=8&recurringDetailsResult.details.0.billingAddress.stateOrProvince=AL&recurringDetailsResult.details.0.billingAddress.street=10+Lovely+Street&recurringDetailsResult.details.0.card.billingAddress.postalCode=35005&recurringDetailsResult.details.0.card.number=6611&recurringDetailsResult.details.0.billingAddress.country=US&recurringDetailsResult.details.0.billingAddress.houseNumberOrName=NA&recurringDetailsResult.creationDate=2016-08-12T13%3A47%3A25%2B02%3A00&recurringDetailsResult.shopperReference=1&recurringDetailsResult.details.0.card.expiryYear=2018&recurringDetailsResult.details.0.paymentMethodVariant=discover&recurringDetailsResult.details.0.additionalData.cardBin=601160&recurringDetailsResult.details.0.billingAddress.postalCode=35005&recurringDetailsResult.details.0.card.billingAddress.city=Herndon&recurringDetailsResult.details.0.card.billingAddress.country=US&recurringDetailsResult.details.0.card.billingAddress.street=10+Lovely+Street&recurringDetailsResult.details.0.creationDate=2016-08-17T00%3A41%3A46%2B02%3A00&recurringDetailsResult.details.0.billingAddress.city=Herndon&recurringDetailsResult.details.0.recurringDetailReference=8314713873062304&recurringDetailsResult.lastKnownShopperEmail=spree%40example.com
+      string: recurringDetailsResult.details.0.card.billingAddress.stateOrProvince=AL&recurringDetailsResult.details.0.variant=discover&recurringDetailsResult.details.0.card.billingAddress.houseNumberOrName=NA&recurringDetailsResult.details.0.card.holderName=John+Doe&recurringDetailsResult.details.0.aliasType=Default&recurringDetailsResult.details.0.firstPspReference=8815022349345739&recurringDetailsResult.details.0.alias=M512442788467272&recurringDetailsResult.details.0.card.expiryMonth=8&recurringDetailsResult.details.0.billingAddress.stateOrProvince=AL&recurringDetailsResult.details.0.billingAddress.street=10+Lovely+Street&recurringDetailsResult.details.0.card.billingAddress.postalCode=54370-6198&recurringDetailsResult.details.0.card.number=6611&recurringDetailsResult.details.0.billingAddress.country=US&recurringDetailsResult.details.0.billingAddress.houseNumberOrName=NA&recurringDetailsResult.creationDate=2016-08-12T13%3A47%3A25%2B02%3A00&recurringDetailsResult.shopperReference=1&recurringDetailsResult.details.0.card.expiryYear=2018&recurringDetailsResult.details.0.paymentMethodVariant=discover&recurringDetailsResult.details.0.additionalData.cardBin=601160&recurringDetailsResult.details.0.billingAddress.postalCode=54370-6198&recurringDetailsResult.details.0.card.billingAddress.city=Herndon&recurringDetailsResult.details.0.card.billingAddress.country=US&recurringDetailsResult.details.0.card.billingAddress.street=10+Lovely+Street&recurringDetailsResult.details.0.creationDate=2017-08-09T01%3A28%3A55%2B02%3A00&recurringDetailsResult.details.0.billingAddress.city=Herndon&recurringDetailsResult.details.0.recurringDetailReference=8414725049542679&recurringDetailsResult.lastKnownShopperEmail=spree%40example.com
     http_version: 
-  recorded_at: Tue, 16 Aug 2016 23:32:02 GMT
+  recorded_at: Tue, 08 Aug 2017 23:28:56 GMT
 - request:
     method: post
     uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
     body:
       encoding: US-ASCII
-      string: modificationRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&modificationRequest.modificationAmount.currency=USD&modificationRequest.modificationAmount.value=2000&modificationRequest.originalReference=7914713903212586&action=Payment.capture
+      string: modificationRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&modificationRequest.modificationAmount.currency=USD&modificationRequest.modificationAmount.value=2000&modificationRequest.originalReference=8815022349345739&action=Payment.capture
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -309,18 +91,18 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 16 Aug 2016 23:32:03 GMT
+      - Tue, 08 Aug 2017 23:28:57 GMT
       Server:
       - Apache
       Set-Cookie:
-      - JSESSIONID=588E8BEBF3FA7C54B3CE1F4438A529D7.test4e; Path=/pal/; Secure; HttpOnly
+      - JSESSIONID=5EF4E5F190367755A11A6C7CF1A8621C.test3e; Path=/pal; Secure; HttpOnly
       Content-Length:
       - '99'
       Content-Type:
-      - text/plain; charset=UTF-8
+      - application/x-www-form-urlencoded
     body:
       encoding: UTF-8
-      string: modificationResult.pspReference=8614713903234904&modificationResult.response=%5Bcapture-received%5D
+      string: modificationResult.pspReference=8515022349371928&modificationResult.response=%5Bcapture-received%5D
     http_version: 
-  recorded_at: Tue, 16 Aug 2016 23:32:03 GMT
-recorded_with: VCR 3.0.1
+  recorded_at: Tue, 08 Aug 2017 23:28:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Credit_Card_Refund.yml
+++ b/spec/cassettes/Credit_Card_Refund.yml
@@ -2,70 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/servlet/soap/Payment
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0"?>
-                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-                  <soap:Body>
-                                <payment:refund xmlns:payment="http://payment.services.adyen.com" xmlns:recurring="http://recurring.services.adyen.com" xmlns:common="http://common.services.adyen.com">
-                      <payment:modificationRequest>
-                        <payment:merchantAccount><ADYEN_MERCHANT_ACCOUNT></payment:merchantAccount>
-                        <payment:originalReference>8514701637548229</payment:originalReference>
-                                    <payment:modificationAmount>
-                      <common:currency>USD</common:currency>
-                      <common:value>2000</common:value>
-                    </payment:modificationAmount>
-
-                      </payment:modificationRequest>
-                    </payment:refund>
-
-                  </soap:Body>
-                </soap:Envelope>
-    headers:
-      Accept:
-      - text/xml
-      Content-Type:
-      - text/xml; charset=utf-8
-      Soapaction:
-      - authorise
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 03 Aug 2016 21:13:22 GMT
-      Server:
-      - Apache
-      Set-Cookie:
-      - JSESSIONID=92DC8C58D103E090BCAD215E16047AE1.test4e; Path=/pal/; Secure; HttpOnly
-      Last-Modified:
-      - Wed, 03 Aug 2016 21:13:22 GMT
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - text/xml;charset=UTF-8
-    body:
-      encoding: UTF-8
-      string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soap:Body><ns1:refundResponse
-        xmlns:ns1="http://payment.services.adyen.com"><ns1:refundResult><additionalData
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><pspReference xmlns="http://payment.services.adyen.com">8614702588023369</pspReference><response
-        xmlns="http://payment.services.adyen.com">[refund-received]</response></ns1:refundResult></ns1:refundResponse></soap:Body></soap:Envelope>
-    http_version: 
-  recorded_at: Wed, 03 Aug 2016 21:13:22 GMT
-- request:
-    method: post
     uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
     body:
       encoding: US-ASCII
-      string: modificationRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&modificationRequest.modificationAmount.currency=USD&modificationRequest.modificationAmount.value=2000&modificationRequest.originalReference=7914713903212586&action=Payment.refund
+      string: modificationRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&modificationRequest.modificationAmount.currency=USD&modificationRequest.modificationAmount.value=2000&modificationRequest.originalReference=8815022349345739&action=Payment.refund
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -81,19 +21,18 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 16 Aug 2016 23:32:12 GMT
+      - Tue, 08 Aug 2017 23:29:04 GMT
       Server:
       - Apache
       Set-Cookie:
-      - JSESSIONID=1318D6B66AE5213C9755CDF694485410.test103e; Path=/pal/; Secure;
-        HttpOnly
+      - JSESSIONID=63EA6C7933E0B119F91CBDF5D591FD69.test4e; Path=/pal; Secure; HttpOnly
       Content-Length:
       - '98'
       Content-Type:
-      - text/plain; charset=UTF-8
+      - application/x-www-form-urlencoded
     body:
       encoding: UTF-8
-      string: modificationResult.pspReference=8814713903329116&modificationResult.response=%5Brefund-received%5D
+      string: modificationResult.pspReference=8515022349447306&modificationResult.response=%5Brefund-received%5D
     http_version: 
-  recorded_at: Tue, 16 Aug 2016 23:32:12 GMT
-recorded_with: VCR 3.0.1
+  recorded_at: Tue, 08 Aug 2017 23:29:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Credit_Card_not_accepted.yml
+++ b/spec/cassettes/Credit_Card_not_accepted.yml
@@ -2,90 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/servlet/soap/Payment
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0"?>
-                <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-                  <soap:Body>
-                            <payment:authorise xmlns:payment="http://payment.services.adyen.com" xmlns:recurring="http://recurring.services.adyen.com" xmlns:common="http://common.services.adyen.com">
-                  <payment:paymentRequest>
-                    <payment:merchantAccount><ADYEN_MERCHANT_ACCOUNT></payment:merchantAccount>
-                    <payment:reference>1</payment:reference>
-                            <additionalAmount xmlns="http://payment.services.adyen.com" xsi:nil="true" />
-                <additionalData xmlns="http://payment.services.adyen.com">
-                  <entry>
-                    <key xsi:type="xsd:string">card.encrypted.json</key>
-                    <value xsi:type="xsd:string">adyenjs_0_1_17$ieJzaq/uC+X8jviG2SYV4qqmma/tCYQZH+SbKa3BfRAbN8j4SL+M4I2F4VRR/BDLimSnATnR2yQxmZFJMx4zZgdr33LGkBSXd6NFeFdWLG3zBbCJQpqEh68Mxw33bzzeh/l7nqrhyMboMoD3U8agpBPwwDHaNNgzpdFbWYq9LtyXgJ4Zd9GisXxamoMTt0QPnT5UqPICfIzF89PdhvXBXQgHOGaAr+W9fWrtZU/a9OYWkxcD+TsiEXjYxseJTKa9M7HBrjmXnBgg+SWukXKHCAREPwb4l8TBLf2ee8ShtdNn3ileKbvsIc5BaEZO+i170b7xcS4ZKb53dVg2gCElfg==$p71bpJx7PaDEexKbukUvonBzC9JkP1G0C5UMYi/KgXTFfZNO2GM2v7sZ3YhB64t5FvQ6Y8QA3QxePxvOMOk+BAehWn1ATRqLCHjgv9cbMHNtPoI2L8N75CP6+dbnfvvcdLxg/vjBPOnw1upUgNQubU7K/PXHsJRjn4sq9E8ko9+E6osLhUbEMM6Cb7+Irp3lj2HkmVshJWOcDeD+739Zxlp2uDU6y/Kbb+Mk3YR1B3Wz67bOzwijF8GXYaNQWfXpGcLk2X82+UXKoesM/govmfcbYUw46Pmwq2TO74j2AX93S5QYvu++RmrXZ0g22JYBhab0SwHXVDBXmMXW4sil4QHz7oJ3uXAkCvSsm8kcYoY8zwZIh0ADLTjjVi6OXc9yGz8coNuPyxVJ7EwRxJgFZf4EpvE7P1bqkZVC8m9wQAtcE3i98yJj+qwkYeUuF8QG4Wwi1dWSWBX9VQwTZW15SZOeMUgAgZUvM7vWimZfPK7hrdyHKgRKmKnrqX93MGLyYRjq4fLcjdxDqRCHSUWpU5eZXIHMyuIqreO+UhNa8WTWmQ8qyLutMrKcjH66A7t1klc9trK8UkfUt9E44ATMq5UnlhuNsyrr3bG31cQY6wALtDXJbPNTKNYWyx5vC6V9OQBDSaVjTmF8RVuJ3Cxgc4hmPv/ehtYTvUjMn8cCjh7RK7EtpiejBK+EhmBqbvFvzwujaYdzuJWu5aVjc8oXhKcIkfYSPlvFezg+xskSuBqLEgUV9JwmPsuPOtnEhAE8QIdSAHgmytrqDB7n801Ls5nF0EzcOQZmpl+ki7oJ17/6TDRUhIBvD+4fm/8Sdc3gtFgq6gF/Bgg2lF39TxASkICLgIjMxmuoDO04JgkCADyMMhDhxkX3XGO9NtAXsAynfhpdqnsuwHL6PPsRyabUaTF4uRGPTYOp5mkGgHWH3kb+dAeDbFasZUCftvxqjsfkRAhdf/N2K7qAswtq8xWFes7yG+BcyffL06BPIaMXCE+l02NrwwZEjO38oBlCwpY+iKzodSvB5+JwNRLvTiwcE64NFWS3McQAuFTle9ajw3plmnBHEMR9ktRGx3FKXKKiq7yxfww2vnUh0GsvhWzh/R01J4ZS9t5Cud/J4s6Q+b/9C1Fww/xGqLFiLnA2DgreHbMF1tePEpIyd6oJerQeLU2U3UxFue9Wd6hcQZnrFak3ZCjSHZIa4/d5T5MWrj++UuT7y3pXvlXXywukJUdVHgzY9hkJq7MvuHtdivvy8hPzQJz5DIO/eo0bCpK20bQn/N63xcVT/i9vL1SQhsV60nUdtXatw9/GGcOlPYmbTkS8cbOn0REH2fM58m01mzHl9BTYyAOOcXeGchG+goUnM+1x3hndjmILfEftXUg2o8ICeZg6XuxNIk9QnSDdTusCZUzY7YSWZbGZQyHevtb6QgfZKmOO3oaAy3PbvHoXWC9p+KtXKzkOOZHnPIcRn/2kzFnD466JSXpM32kuxPdI9XLtPtV4wtvHCGjqsESmwI5d7pInBVQQlSjQk5MsgPt4qrhQdWmMtIaTqsd7tjbunakEOmHwq+beu4c61PnCNdO1iVpLLIrcwt4ZcZFzASGvtWleg607qzBFsgY5opZuaPHmYcHG5KDjL5BtVITk100Cv0YgenI8M2Sz/BDjhP3GDgjCFccvgbg2ULmYL+C84iYG/eUC6TbaqSNiR1QBz1t48srJESc6/8ZhX+WqQuADMAXuzDEQ7aT7wW4DjkUEajLqNX6f+IXDheqIPxQWlhVkyVdZkQFdaL55yvoAs3CYbByQ9rhIkuLNsU6NJlBRRoawfEXg4xkvJIAEG5siWYfVEZE5fjnSZLBkqsZCLN4Tg1JS1Nig1jxnuoeh94+/T5vlrkCw6DmoDNcPVvH9f7RNEsp/hjiOK1Z2B1RUfEWInXuBL5ZORktJ2TSufoSQcxn0AZYR3L84A+QdCFC5Alw6PmWeOXXht5zFy9iF/1NhYOHpNcs44qhSIwjcfykBx95PfJEwDa+84zmQ3S+60Ts5yyTnHQOyNYLkrXvVxIsP9FF3gjUzUAHam1qoQiFykK5QWfmTXtx++ghh21FMUfw3VQrtp/7TIOpCThG5GYW8n/PS+FD/MGA12UxMAEnBCJC60MQxFaamV4wcAnMfVvvYVHb0mbwklkxW46EF9JqR1HSyDzIdDDpdfEJwNrCs91N9xYJFldcITCE/7xUjFgHGTZ6oqGKCpc5HedOrU/tvXHcjbGPkDrGjL6mVc2AZSFgzeXq7gxtXHoVEe7P5MSjPKK3buxLwQOFyb1dTLO2hC+3t9KFDQ0Y2MyATkBlHNOYMO2H0gE+HLtivnpuaBlb3MA==</value>
-                  </entry>
-                </additionalData>
-                <payment:recurring>
-                  <payment:contract>RECURRING,ONECLICK</payment:contract>
-                </payment:recurring>
-                <payment:amount>
-                  <common:currency>USD</common:currency>
-                  <common:value>0</common:value>
-                </payment:amount>
-                <payment:shopperReference>1</payment:shopperReference>
-                <payment:shopperEmail>spree@example.com</payment:shopperEmail>
-                <payment:shopperIP></payment:shopperIP>
-                <payment:shopperStatement>R138661687</payment:shopperStatement>
-                  </payment:paymentRequest>
-                </payment:authorise>
-
-                  </soap:Body>
-                </soap:Envelope>
-    headers:
-      Accept:
-      - text/xml
-      Content-Type:
-      - text/xml; charset=utf-8
-      Soapaction:
-      - authorise
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 02 May 2016 15:24:16 GMT
-      Server:
-      - Apache
-      Set-Cookie:
-      - JSESSIONID=1622169246CC5C366FFD567D2F3C4479.test4e; Path=/pal/; Secure; HttpOnly
-      Last-Modified:
-      - Mon, 02 May 2016 15:24:16 GMT
-      Transfer-Encoding:
-      - chunked
-      Content-Type:
-      - text/xml;charset=UTF-8
-    body:
-      encoding: UTF-8
-      string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soap:Body><ns1:authoriseResponse
-        xmlns:ns1="http://payment.services.adyen.com"><ns1:paymentResult><additionalData
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><authCode xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /><dccAmount xmlns="http://payment.services.adyen.com" xsi:nil="true"
-        /><dccSignature xmlns="http://payment.services.adyen.com" xsi:nil="true" /><fraudResult
-        xmlns="http://payment.services.adyen.com" xsi:nil="true" /><issuerUrl xmlns="http://payment.services.adyen.com"
-        xsi:nil="true" /><md xmlns="http://payment.services.adyen.com" xsi:nil="true"
-        /><paRequest xmlns="http://payment.services.adyen.com" xsi:nil="true" /><pspReference
-        xmlns="http://payment.services.adyen.com">8614622026565096</pspReference><refusalReason
-        xmlns="http://payment.services.adyen.com">CVC Declined</refusalReason><resultCode
-        xmlns="http://payment.services.adyen.com">Refused</resultCode></ns1:paymentResult></ns1:authoriseResponse></soap:Body></soap:Envelope>
-    http_version: 
-  recorded_at: Mon, 02 May 2016 15:24:16 GMT
-- request:
-    method: post
     uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
     body:
       encoding: US-ASCII
-      string: paymentRequest.reference=R981703707&paymentRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&paymentRequest.amount.value=2000&paymentRequest.amount.currency=USD&paymentRequest.billingAddress.street=10+Lovely+Street&paymentRequest.billingAddress.houseNumberOrName=NA&paymentRequest.billingAddress.city=Herndon&paymentRequest.billingAddress.postalCode=35005&paymentRequest.billingAddress.stateOrProvince=AL&paymentRequest.billingAddress.country=US&paymentRequest.additionalData.card.encrypted.json=adyenjs_0_1_18%24u6WAAlZ8uGGD4dphVQFdsOsmZ6vthAknRbXV7Kk8zMqgoAPh2LgARxmwhY7FFXgp8ye8wPJJz%2BWCg0lKcelv4SQeUFlN9C2kU%2Fn%2BClS1vjyLvOdRMRiloM%2FzXkFUt%2B60ZO8QsudId08ZfhDM5f%2Br5grHZ%2FlIfQYIck89xHk%2FaHEXjvKX8Ciyu3WEX%2BC12jOqvx5JHc9YqHIhY66rGpkzftURMT06XBhb807FZUrruB6QbZW6W%2BiyBLG5WJOKPXPTIMdeCVw04T5uPA1Ith9z9PKxxvr4XBWv8yHW41ZbhYPoeS7Shg5DKDy0zO9BqHLCP3%2BZr7iNCKhzJ819snK0wg%3D%3D%246iV1FGE5zBsIgNIO%2BeBB7khE8C%2B3bfCdZkAg2PiV3lvwT9GOVS6tlqC0zb9ZxQ8TkJerkSyHBlJLN3xvzNJG%2FGuGBfK0MqJUXERbe74nh8i%2FX72wos1r65rEex4HLoCAoGScDnHcv0kEAjwkT3gf08L288Iq6NnxDKchnVfLIG3ZZ1TyKEzj8DIUnx9vlia5%2F4%2FnzBoaxBUjKdO7qcxq%2B3F1lDNDnRx8XzUH%2F3lBe8D5B0OdjNbTRUTbJlpz3%2FaOzJOU8ukE7tnTmDgE43CSUaDcIqJ71MaWvtXMVDSAeK0jJCu7DRc4kYS0BqHV%2FRtV91hwSeRXCrF8%2B4g98iezO7FteIm2kUjWG7u6kJgr%2BKah3AXnHlRynuOoLw%2BVZKcIFug214QC%2FMS0gnCu4F%2BNSJ4Kf%2BN%2F9Ki4UNfWSFaCxQ8X0RytIeqO0Ar2h34gMtCcGTDKlOBup3sUUu2yLyjGdAUss7jdtvRis7PLMwckT8yUom4U1rkT158HluwFxxIBqt1W5g2iF3ozlOROheT0%2BPpGKO0OaK2c5%2BTv82kAqdoDXkQ4%2FmZj54oS1e1yCUncfMfLJLv7TNeBeF%2BR9y52Ot2y8dLZJN3ZxClWnk3AUjuoHrcsemFstjiYG5ER%2FRVgnkvQMqOCVn0M%2FAy%2B0c%2F2%2BwBzvvQSvTwlAM7pfDeS8Gra%2F33pYOZvWd69ZasXlLaVxR593Dt4eqloa657Th3uCxATujT1okRJ%2BoIAzWZUEEyXsmehGINRcLFi0AI3cio%2BzrJxfYVYcuf9ESShxv25gm1iHdlI65ZJQ6zPFPUqFU1B4cEY28vWxrnwUP2ltJnRB6bironIHzGp2sZTBB66hKWoBLOz8XtVBGY8VgP0zgtuDvx6EEOdQX0n2Z3tb6OzdxeDFho%2FaEPviJSTzCEMdk%2Bna5DYvFszqSBKzkQzzqi5q5KB0nIMkzHeckwtm6XNZkJAUTew%2BrP82hBbgmDJ19HC2IkZX%2B%2BgOwN74%2B6dcYnJidEz5VZPvWJVEIlzUzhGCo1erus7oS33akxyPJ%2BnwG%2B1Xjag%2F7QgRTjmhcSHWgFQpdPi4Qi4nQ5gKv7LglEOCuvSodhf5DOVGp2dOBl4KbXSx5KnPJLEVhu52wZ9LGNRm62qR4UHw8MBG3a6%2FvsJIXQZnvlQeF3NEKaPAtdZmnG8nOv%2FL9HQiZebOIQWW7hIELpY5dPOWq%2FUeEMXqh0O7UVnHkuAP83%2FWVSydo1ke82bIikT5zAm8EuB%2F9W%2FBuksKUx7%2Fg2wx38r5MB2tT5soqaEck2Ke6OleuGpMXyvqIyCusoo0DNifl6kPcrwJRL8TvcAoAWyRpQtaYr19i8hRCN2wuxa199kgUB2Asl27Eq%2B%2F9ISBVnkicQAmg%2FY%2Blb5bJ8a%2BtSQOcqzR2YU%2BVBOG%2FGQxE7HxhrmsWjV6OEF3pe75CvC45VjcP7v5bQMaLO7NmocQW6bN8GoTT%2BLUlr3Zk7Z8eIYnl58DofRlvxX0O5Cd39F%2BZ9klkF0UBkXRmVuXE3Crm9NbUHWyv8vQjxk%2BiMaNie08cG%2FELFVWnfnHfwwjbXryGdL4kjLYIvTr1L8WxbndmrN%2BNZdHHzQFW7ew8wnZP5EtXYWWETlzgANFwQLi22ED%2F5LH2Q7wGGSStlY01G31Qk%2F6n%2FDw1isVeu0UgG3TrueoYG4Vguu60G%2Bh17qlNn8746bQErHMsJetwFKFZt9j%2BWdYVEz2GPqPwLgL8PCRek0RTSrStV6GjZ182rlrzT91tb6R0dx1chz7wIr4TQnRxuOXT3tPnWRY6PLKnBJOrdLxzPzpN6z%2BrhjdB1%2B6rUGx63OxHkbaNlbfNxOj4WaRMw8%2FzvUwx4VVcBPkxqnkOack0tsivG180M2o2PFvp8NVG16i3%2FQeaWGtFzowgVjoQk%2F8z4i4kpV%2Fsn3RNEqh8OG3gHmsz%2FDScmFwie2eS7KHC3JTuSAosnW8bYiZAj3fFRQkf7xA%2F2Ja1mR2OlL7WHMq%2BkcYlsGwW8g5hjGoZzp5kYP%2BnlRsBa%2BmYIBfvOpRoq1QnpruehCRbHV6qzMTi7dk4OY0jxHKep%2F3PkYBRZeqMS5DkDYBYuH8uN9NcVCCajODp7o6gMHu918C5C4w%2Bxqdx3kBdI21B6zU2p3EOZ%2BRUeILYQDHuigrtGND7eyWakDyBgXuWdnTn%2F9klfhunU9SiPlkF6Kjrbqu9kb7%2BLdml392INaq%2ByFT3HF5rDLaKs6bdxAXBQh53%2Folb2qV2zoaXXeLztHdrd0Z19xfWjxEH1l%2FXSeHedhDi4XI%2BNFJdVVcKkmmLmL%2B9lFStp6ZMqYmWhPOy3IXlDqANiSHdNOiqJFXn2m6JQgLrdy5etkdFpYcI1HJZqhMtr0Kz8wy1yW7JiZ8JQzlx5%2FAYzD2j50Kr9F0DOwmgvU05tL1lN8tyvRNG5d2q5fVA1IIariGjYsGzRglB602HUOVQzoysOQ8y7v4jouuW%2BNW%2FHyUX8TRG%2Fkf1qr%2BqkM9SgQQGV3pMqUgvIsw6Uz54uGHZHZa99xndGp258jrBBjRL9oyk2VojDBkvfG33XALnRKXHfnRIlJzuuPjeAy%2BcwqJCBAFLHtgZ2H7czx3YOZgQMXXAV1Fd7de%2Ft5iwRNuxPIpxr%2FZ1TKy1VrM4L1cv%2FDS6d%2FA9rdkZB3gWGwjKDHSSIMr906bi60xhTawJES2mrBtlnbjoZjj7w%3D&paymentRequest.shopperIP=&paymentRequest.shopperEmail=spree%40example.com&paymentRequest.shopperReference=1&paymentRequest.recurring.contract=RECURRING&action=Payment.authorise
+      string: paymentRequest.reference=R308079643&paymentRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&paymentRequest.amount.value=2000&paymentRequest.amount.currency=USD&paymentRequest.shopperIP=&paymentRequest.shopperEmail=spree%40example.com&paymentRequest.shopperReference=1&paymentRequest.billingAddress.street=10+Lovely+Street&paymentRequest.billingAddress.houseNumberOrName=NA&paymentRequest.billingAddress.city=Herndon&paymentRequest.billingAddress.postalCode=79034-2999&paymentRequest.billingAddress.stateOrProvince=AL&paymentRequest.billingAddress.country=US&paymentRequest.additionalData.card.encrypted.json=adyenjs_0_1_18%24OPv4xmCNIuiAZSInTxQXKqARvJZq4ilHN7kek9W5wlAHyl%2BP9x74TiuHVzZOacO1%2BvN%2Bm%2FO1vZ%2FyUAzFtvz5Z%2Fg%2FO5nYpCpsHxTqmS5%2F5BJMLGxhpjkmNuus%2FGRvw0oQMF66cvFE9qEF6ypBPSdbhAM2hClFl%2BK%2BV55rWTdCl16jTVxyAlT5K3zLw72BWJrDeMnyWjVF1wnl%2FGvzeqRdqNC8Zt66bFu74kGKY6N7ij6XYqOSlq3%2Fq0bJzlPgz2mdkCbkDEZfXMO1T60m%2FRLT5Ac47ocUvnMtX%2B0dSiFt6F9oqSxnNN2Pwre5sZ6sZxxueIW8Nn09hgNDtPmg5ifhfA%3D%3D%24p3HO52iiTA44ni9OfnRj8pA0iH9sRFf0FZw4ds%2BP%2BZ1k4us4gPgciIW5VC31NqAMsF0X8aaevCDJacbT%2F5HbtgQz266RfmcQoV0MApgPHia%2FG2dW86lNaW0PcvaxY0HRxwH%2Fz4oNNlC34bEx%2BSyQs7OkYGBGF4CdLlEVS%2Bwexw6tOBTeuvsq%2F3H3YOwG616%2B8ZRunMh%2FGgBBGa8jFvQMfM2U3zoHIH22BVr428TEtyX1ER5bu2C4m45DSqhnAypmPhajM5Q8OCS8LmF0ivwmRjW29fpTj6MHq9LKrwSMJW3HkNSNMMMbP2qSgrlxjPxn01k0CwYhppubKpSXt439sX%2FkewbY16QbhgC5mJ1lB3mdRV9uHbKRnOHmtX0ygZ0m7LHffB%2BbGefGttkcq%2BQsGEBeI5aLbWDmt%2FWs9u2usFEj6Vs165N%2FWpyeUdnNOqqHP4tp6GDJiO%2BFbftGb5ph4mYBVJ09LuR%2BhSPtIgvmRCenEDcsMVgpZNayFmO1ZMtKqIfaDydmSrHYRTnwfg0XzsNcqX0kp1N00RH%2FWkkVQp8ILBIyl8o0MoDMITqohzw5%2BbvDidQI8n5XNshjGLpfe4ltb%2FrNBCFwTKuWyGIxXMC6TsIshnzaBflzKWDt5%2FcP0%2FibSgee2YC2XOS%2BWhR6TjinohM9yU86r1kxWHXtR6aQJZ0kIfIkpxYtejK9CqCzngJwW7nV50UOIygYPPqdwOYINrdVZ%2B9gugZBknf3%2Fmj9AbXs1rQAzx8ODWI58HUy92NGUchbkXQQuUkiefOldxRNLCHEudsEYLQlyiB%2BgmP6Z%2F2rhFTbvWDOX5xbhq5M4pJ0JXULxW8yT0%2B2QHOweYpg9%2BwpnmqRzvXFD5DolXqKK2Dgpaj3MQBwI6Mxpz%2BKLTVENJdk%2FRpApnBajz7tQ9PdZO8rf0z1WJnODbc8tvsY%2FerZ%2BD3tBVt9ju%2FqLDgLxFtI%2Bpi5fqf9uIrteUo8WjJoPjRLrFOJVUEpwRIaHMkDkthml7pwuX89StF7s9asfo1t2qnvmi5z4Kaih7vHaQqw2BSTW44My15fnnkTsJTtMe5%2BBUWAoW8IXVEQ2TVJbkMIr1tFsrrgcH0c91UjAvqrRanrSKh%2FhrPpBtS4rCqITY1c43s2vTadfg88JaSfp6oC%2FjreCV%2FHTvVomZhy00N76xhwN9NBwVubXtvvStFYElcFQb3wd6W6pBE%2Bq3EYDegKmw7HsJsYDD24tk1NVNRa2YvqaN%2BEUni5%2BFshiddOO1qDw%2F3CDFW0HROpz5RihM64mR%2BUOOWgkMiyJFDyjDGPeiESgk%2BiRsJrt%2FygI%2B%2Fo47kZBQzJHKa6YyZrooEDRBoyAw249vLLsjcbpbUf%2B0YEX%2BXkKC3IZMEWyMLfe5W1W3mBWM6yffBw3wQS9hN1ujFeECrb3Jo4PY0RGvjeSrl4G%2BhLK%2FA4tejnmWDBwnrZZ8XaFVVKt5iPBxAmQkMhUsGSsu6UZEUdrrCFTa5ymYw70GVA9rYG3t1xTst7jOwJOV2PlECnkhE%2F1AbGiNlk6YQdi8d4SDTMzQHvz08ZJX7n2TA9NiaLVw3o36Vc8MGGA2oqw259Oqy%2BYkDfhb%2Fu6MY7d0X%2FyhUb%2FqoDaAHLujY4xBCPpexEU4FjBZzGfV%2Bzs%2FwzGOAWMe0Bw2%2F8Sf%2FrBfkjX50pJjC27uh4FG9Gf77ZMPasP2dHlR5rC7aHEffyWRzdyU5inWafAVrk7eGTGUn4xFnvuq%2BiL%2FWn7WSiaV8djh4uIGLJ77ooQVbhl6QL86DOP2iz8HeWBaL9kYWiRB0PK4RXMA3oy0EBOrjCrf%2FhJjpJl%2BjD9lbkwDW8HK9FQKtBS2q3Wg3tojkebEiWwRJrhOpY4CyQfC%2F2zPDVRKw8oDqxlZ7iucWYjmCiQ1Iur%2BAVZohjjCga9sM8jiH8HSeE90MqpSG9J4RqT9tHVfbfIAalG7TpV0d79UKXxb9ibWaliQec7l8DwRei6nzEsKjHcbXT5lUSpKRnYZJ%2BdfNk82%2B6DX2bYUFO7kgmZvv8HLQmIVdCxHpYazv9w8NCB6Q2gG1yov9utvjaX1N6KNlvECLbC3z6S9epc6PlzEUIzWHC%2BBDZ03TGo7U0TGnHaT0xpMlDNmGg66hlghJ2gg9zS0P6BM7QyoVrGqol3xz6xniYNNXZGwBNxImOcGxuQaO4Xrhk%2BzmNr6X%2BFHOrmYbKjExnPjExAGx4554sptgo9nmLcezBpXnMhkjL17uYbYEqovnVRxwZmTfCeRCTI7QMRie1sLL9eXAl%2FopIa5kBM323FbVH1m9yPHblG5f7O2NbSn7otdUji7KwnsO%2FW%2B5QNmZw7pe3VW8OmSHN6In0pZ5%2BGqj6TzrG%2BRZSvVt3%2Fpn%2BvEmMg%2BEbtDhnlICp%2B6DQYsfXG25egRbL%2FSTZtI9tCZ4NpFT%2BAAhCL9vrM2xm34CPwNYKyWq8ccl8hpFCL70RvNDjTdvaCO6LSuhW7W%2F7YbvNNNz3YGye29kcG%2BLwgWVS8PXjB8ITFshC8CZOjB5210EMwy%2Fx0s8iP%2FOSNhE8ad%2FxQ2LaTSx1QmavDo4CIrvKAxDqSxkX993YVhg2Ka1j5PYJH3SuueA5OFIYHNFop9vOnRI0doXOZg0SQLQc5ZDVrjvMREV55yTVQfW5d50DlXk0HW6UbGVrFseFmCUV3KmlnHYtbNs6fIwnK8bX1xOHyqzzd4c%3D&paymentRequest.browserInfo.userAgent=Mozilla%2F5.0+%28Unknown%3B+Linux+x86_64%29+AppleWebKit%2F538.1+%28KHTML%2C+like+Gecko%29+PhantomJS%2F2.1.1+Safari%2F538.1&paymentRequest.browserInfo.acceptHeader=text%2Fhtml%2Capplication%2Fxhtml%2Bxml%2Capplication%2Fxml%3Bq%3D0.9%2C*%2F*%3Bq%3D0.8&paymentRequest.recurring.contract=RECURRING&action=Payment.authorise
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -101,18 +21,18 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 16 Aug 2016 23:31:50 GMT
+      - Tue, 08 Aug 2017 23:28:45 GMT
       Server:
       - Apache
       Set-Cookie:
-      - JSESSIONID=582C5DB94AE1824BAB4C451C955FE376.test3e; Path=/pal/; Secure; HttpOnly
+      - JSESSIONID=85ED391357EA417EAF798C5DE5A042C3.test3e; Path=/pal; Secure; HttpOnly
       Content-Length:
       - '117'
       Content-Type:
-      - text/plain; charset=UTF-8
+      - application/x-www-form-urlencoded
     body:
       encoding: UTF-8
-      string: paymentResult.resultCode=Refused&paymentResult.refusalReason=CVC+Declined&paymentResult.pspReference=8514713903102276
+      string: paymentResult.resultCode=Refused&paymentResult.refusalReason=CVC+Declined&paymentResult.pspReference=8525022349251383
     http_version: 
-  recorded_at: Tue, 16 Aug 2016 23:31:50 GMT
-recorded_with: VCR 3.0.1
+  recorded_at: Tue, 08 Aug 2017 23:28:46 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/adyen_capture.yml
+++ b/spec/cassettes/adyen_capture.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://<ADYEN_API_USERNAME>:<ADYEN_API_PASSWORD>@pal-test.adyen.com/pal/adapter/httppost
     body:
       encoding: US-ASCII
-      string: modificationRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&modificationRequest.modificationAmount.currency=USD&modificationRequest.modificationAmount.value=11000&modificationRequest.originalReference=7914483013255061&action=Payment.capture
+      string: modificationRequest.merchantAccount=<ADYEN_MERCHANT_ACCOUNT>&modificationRequest.modificationAmount.currency=USD&modificationRequest.modificationAmount.value=2200&modificationRequest.originalReference=7914483013255061&action=Payment.capture
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -21,18 +21,18 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 16 Aug 2016 23:32:53 GMT
+      - Tue, 08 Aug 2017 23:29:10 GMT
       Server:
       - Apache
       Set-Cookie:
-      - JSESSIONID=9D4B58CC45D6C4A07E880368DEB565A7.test4e; Path=/pal/; Secure; HttpOnly
+      - JSESSIONID=E3CB339EE8111923C4B17E36819BAEA4.test4e; Path=/pal; Secure; HttpOnly
       Content-Length:
       - '99'
       Content-Type:
-      - text/plain; charset=UTF-8
+      - application/x-www-form-urlencoded
     body:
       encoding: UTF-8
-      string: modificationResult.pspReference=8614713903735488&modificationResult.response=%5Bcapture-received%5D
+      string: modificationResult.pspReference=8515022349507398&modificationResult.response=%5Bcapture-received%5D
     http_version: 
-  recorded_at: Tue, 16 Aug 2016 23:32:53 GMT
-recorded_with: VCR 3.0.1
+  recorded_at: Tue, 08 Aug 2017 23:29:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/features/credit_card_processing_spec.rb
+++ b/spec/features/credit_card_processing_spec.rb
@@ -42,14 +42,14 @@ shared_context "complete credit card payment" do
   end
 end
 
-describe "Entering Credit Card Data" do
+describe "Entering Credit Card Data", js: true, truncation: true do
   include_context 'checkout setup'
 
   it "shows the adyen gateway as an option" do
     expect(page).to have_content("Adyen Credit Card")
   end
 
-  context "when the adyen gateway is selected", js: true, truncation: true do
+  context "when the adyen gateway is selected" do
     context "and the form is not filled out" do
       it "displays an alert on submit and validates the form" do
         choose('Adyen Credit Card')
@@ -115,7 +115,7 @@ describe "Entering Credit Card Data" do
     end
   end
 
-  context "when the adyen gateway is not selected", js: true, truncation: true do
+  context "when the adyen gateway is not selected" do
     context "and the form is not filled out" do
       it "submits the data from the other gateway" do
         choose('Credit Card')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,6 +59,12 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.include Spree::TestingSupport::UrlHelpers
 
+  config.when_first_matching_example_defined(type: :feature) do
+    config.before(:suite) do
+      Rails.application.precompiled_assets
+    end
+  end
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ require "database_cleaner"
 require "capybara/poltergeist"
 
 require "spree/testing_support/factories"
+require 'spree/testing_support/capybara_ext'
 require "spree/testing_support/controller_requests"
 require "spree/testing_support/url_helpers"
 require "spree/testing_support/authorization_helpers"
@@ -38,6 +39,9 @@ FactoryGirl.definition_file_paths = %w{./spec/factories}
 FactoryGirl.find_definitions
 
 Capybara.javascript_driver = :poltergeist
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
 
 RSpec.configure do |config|
   RSpec::Matchers.define_negated_matcher :keep, :change
@@ -57,6 +61,10 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each, type: :feature, js: true) do |ex|
+    Capybara.current_driver = ex.metadata[:driver] || :poltergeist
   end
 
   config.around(:each) do |example|


### PR DESCRIPTION
These overrides are left over from when we used the SOAP API implementation in the Adyen gem. We've fully switched over to the REST API, so this code is never used anymore.

I had to re-record the VCR cassettes since the request format is completely different now.