### PR TITLE
Include recurring profile reference in reauthorize requests

### DIFF
--- a/app/controllers/spree/adyen_notifications_controller.rb
+++ b/app/controllers/spree/adyen_notifications_controller.rb
@@ -31,7 +31,7 @@ module Spree
 
     private
     def accept
-      render text: "[accepted]"
+      render plain: "[accepted]"
     end
 
     def notification_exists? params

--- a/app/models/spree/gateway/adyen_credit_card.rb
+++ b/app/models/spree/gateway/adyen_credit_card.rb
@@ -78,7 +78,9 @@ module Spree
         )
       elsif payment.source.has_payment_profile?
         rest_client.reauthorise_recurring_payment(
-          authorization_request(payment, false)
+          authorization_request(payment, false).merge!(
+            selected_recurring_detail_reference: payment.source.gateway_customer_profile_id
+          )
         )
       else
         raise EncryptedDataError


### PR DESCRIPTION
The way this is currently implemented, it will use the shopper reference to find any potential recurring payment contracts and automatically use the latest one. This can cause problems because the shopper reference we use is either the `user_id` if one exists and otherwise the order number. If an order is initially placed as a guest checkout and later associated to a user, the recurring profile lookup will fail.

We already store the recurring profile reference on the payment source (`Spree::CreditCard`), so we should just pass in the one we have on file explicitly.