### PR TITLE
Remove char limit from PSP references

### DIFF
--- a/db/migrate/20170905173321_remove_char_limit_from_psp_reference.rb
+++ b/db/migrate/20170905173321_remove_char_limit_from_psp_reference.rb
@@ -1,0 +1,9 @@
+class RemoveCharLimitFromPspReference < SolidusSupport::Migration[4.2]
+  def up
+    change_column :adyen_notifications, :psp_reference, :string, limit: nil
+  end
+
+  def down
+    change_column :adyen_notifications, :psp_reference, :string, limit: 50
+  end
+end


### PR DESCRIPTION
For any type of payment notifications, we're guaranteed that the psp
reference is a unique 16 digit identifier.

However, Adyen also sends different types of notifications, such as when
reports are available. For these types of notifications the psp
reference is a string according to the documentation:
https://docs.adyen.com/developers/marketpay/marketpay-notifications/receive-notifications/report_available

The strings returned in the psp reference are typically file names for
the report, and can exceed the 50 character limit we've set. It's
unfortunate that they use this field inconsistently, but with this limit
if any notification exceeds it, Adyen will stop sending notifications
because we don't respond with the `[accepted]` string.