### PR TITLE
Rails 5.1: Fix passing params to Adyen gem

### DIFF
--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -104,7 +104,7 @@ module Spree
     end
 
     def check_signature
-      unless ::Adyen::HPP::Signature.verify(response_params, @payment_method.shared_secret)
+      unless ::Adyen::HPP::Signature.verify(response_params.to_h, @payment_method.shared_secret)
         raise "Payment Method not found."
       end
     end


### PR DESCRIPTION
In Rails 5.1 without this we get this error:

    NoMethodError: undefined method `sort' for #<ActionController::Parameters:0x000056354bbf6f68>

in here:

    def sorted_keys(hash, keys_to_sort = nil)
      hash.sort.map{ |el| el[0] }
    end

from:

    adyen-2.2.0/lib/adyen/signature.rb:49:in `sorted_keys'
    adyen-2.2.0/lib/adyen/signature.rb:37:in `string_to_sign'
    adyen-2.2.0/lib/adyen/signature.rb:17:in `sign'
    adyen-2.2.0/lib/adyen/signature.rb:28:in `verify'
    adyen-2.2.0/lib/adyen/hpp/signature.rb:30:in `verify'
    solidus-adyen/app/controllers/spree/adyen_redirect_controller.rb:116:in `check_signature'