### PR TITLE
Ensure adyen credit card cse library path is asset pipeline compatible

### DIFF
--- a/app/models/spree/gateway/adyen_credit_card.rb
+++ b/app/models/spree/gateway/adyen_credit_card.rb
@@ -13,7 +13,7 @@ module Spree
     end
 
     include Spree::Gateway::AdyenGateway
-    preference :cse_library_location, :string
+    preference :cse_library_location, :string, default: ''
 
     def cse_library_location
       ENV["ADYEN_CSE_LIBRARY_LOCATION"] || preferred_cse_library_location

--- a/spec/models/spree/gateway/adyen_credit_card_spec.rb
+++ b/spec/models/spree/gateway/adyen_credit_card_spec.rb
@@ -27,7 +27,7 @@ describe Spree::Gateway::AdyenCreditCard do
     context "with no preference set" do
       before { ENV["ADYEN_CSE_LIBRARY_LOCATION"] = nil }
 
-      it { is_expected.to eq(nil) }
+      it { is_expected.to eq('') }
 
       context "with an environment key set" do
         before { ENV["ADYEN_CSE_LIBRARY_LOCATION"] = "SUPERTOKEN" }


### PR DESCRIPTION
A return value of `nil` is incompatible with Rails' asset helpers, e.g. javascript_include_tag.