### PR TITLE
Remove credit cards image

### DIFF
--- a/app/views/spree/checkout/payment/_adyen_encrypted_cc.html.erb
+++ b/app/views/spree/checkout/payment/_adyen_encrypted_cc.html.erb
@@ -1,5 +1,3 @@
-<%= image_tag 'credit_cards/credit_card.gif', :id => 'credit-card-image' %>
-
 <% content_for :head do %>
   <%= javascript_include_tag payment_method.cse_library_location %>
   <%= javascript_include_tag "spree/checkout/payment/adyen_encrypted_credit_card" %>


### PR DESCRIPTION
The coming soon alternative/replacement of solidus frontend,
solidus_starter_frontend, will not provide this image in its assets.
Furthermore, this is a low res image that most of the time gets deleted since the early
stages of customization.