### PR TITLE
adds support for rails 5.2

### DIFF
--- a/app/models/adyen_notification.rb
+++ b/app/models/adyen_notification.rb
@@ -37,7 +37,7 @@ class AdyenNotification < ActiveRecord::Base
   REFUNDED_REVERSED = "REFUNDED_REVERSED".freeze
 
   belongs_to :prev,
-    class_name: self,
+    class_name: self.to_s,
     foreign_key: :original_reference,
     primary_key: :psp_reference,
     inverse_of: :next
@@ -45,13 +45,13 @@ class AdyenNotification < ActiveRecord::Base
   # Auth will have no original reference, all successive notifications with
   # reference the first auth notification
   has_many :next,
-    class_name: self,
+    class_name: self.to_s,
     foreign_key: :original_reference,
     primary_key: :psp_reference,
     inverse_of: :prev
 
   belongs_to :order,
-    class_name: Spree::Order,
+    class_name: Spree::Order.to_s,
     primary_key: :number,
     foreign_key: :merchant_reference
 


### PR DESCRIPTION
**Description**
This just adds support for rails 5.2 fixing

`A class was passed to `:class_name` but we are expecting a string.
`